### PR TITLE
Added support for configuration file using Viper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ docker-compose up --build
 ## Building
 
 To run without docker you will need to first build, then setup the postgres DB,
-and pass the user, pass, name, host, and port to the application as environment variables
+and pass the user, pass, name, host, and port to the application as environment variables 
+or in a config file.
 
 ```
 DB_HOST=
@@ -66,6 +67,36 @@ pkger
 ```
 go build
 ```
+
+# Configuration
+Thunderdome may be configured through environment variables or via a yaml file `config.yaml`
+located in one of:
+
+* `/etc/thunderdome/`
+* `$HOME/.config/thunderdome/`
+* Current working directory
+
+The following configuration options exists:
+
+| Option                     | Environment Variable | Description                                |
+| -------------------------- | -------------------- | ------------------------------------------ |
+| `http.cookie_hashkey`      | COOKIE_HASHKEY       | Secret used to make secure cookies secure. | 
+| `http.port`                | PORT                 | Which port to listen for HTTP connections. |
+| `http.secure_cookie`       | COOKIE_SECURE        | Use secure cookies or not.                 |
+| `http.domain`              | APP_DOMAIN           | The domain/base URL for this instance of Thunderdome.  Used for creating URLs in emails. |
+| `analytics.enabled`        | ANALYTICS_ENABLED    | Enable/disable google analytics.           |
+| `analytics.id`             | ANALYTICS_ID         | Google analytics identifier.               |
+| `db.host`                  | DB_HOST              | Database host name.                        |
+| `db.port`                  | DB_PORT              | Database port number.                      |
+| `db.user`                  | DB_USER              | Database user id.                          |
+| `db.pass`                  | DB_PASS              | Database user password.                    |
+| `db.name`                  | DB_NAME              | Database instance name.                    |
+| `smtp.host`                | SMTP_HOST            | Smtp server hostname.                      |
+| `smtp.port`                | SMTP_PORT            | Smtp server port number.                   |
+| `smtp.secure`              | SMTP_SECURE          | Set to authenticate with the Smtp server.  |
+| `smtp.identity`            | SMTP_IDENTITY        | Smtp server authorization identity.  Usually unset. |
+| `smtp.sender`              | SMTP_SENDER          | From address in emails sent by Thunderdome.|
+
 
 # Let the Pointing Battles begin!
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"log"
+	"github.com/spf13/viper"
+)
+
+func InitConfig() {
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+
+	viper.AddConfigPath("/etc/thunderdome/")
+	viper.AddConfigPath("$HOME/.config/thunderdome/")
+	viper.AddConfigPath(".")
+
+	viper.SetDefault("http.cookie_hashkey", "strongest-avenger")
+	viper.SetDefault("http.port", "8080")
+	viper.SetDefault("http.secure_cookie", true)
+	viper.SetDefault("http.domain", "thunderdome.dev")
+	viper.SetDefault("analytics.enabled", true)
+	viper.SetDefault("analytics.id", "UA-140245309-1")
+	viper.SetDefault("db.host", "db")
+	viper.SetDefault("db.port", 5432)
+	viper.SetDefault("db.user", "thor")
+	viper.SetDefault("db.pass", "odinson")
+	viper.SetDefault("db.name", "thunderdome")
+	viper.SetDefault("smtp.host", "localhost")
+	viper.SetDefault("smtp.port", "25")
+	viper.SetDefault("smtp.secure", true)
+	viper.SetDefault("smtp.sender", "no-reply@thunderdome.dev")
+
+	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
+	viper.BindEnv("http.port", "PORT")
+	viper.BindEnv("http.secure_cookie", "COOKIE_SECURE")
+	viper.BindEnv("http.domain", "APP_DOMAIN")
+	viper.BindEnv("analytics.enabled", "ANALYTICS_ENABLED")
+	viper.BindEnv("analytics.id", "ANALYTICS_ID")
+	viper.BindEnv("admin.email", "ADMIN_EMAIL")
+	viper.BindEnv("db.host", "DB_HOST")
+	viper.BindEnv("db.port", "DB_PORT")
+	viper.BindEnv("db.user", "DB_USER")
+	viper.BindEnv("db.pass", "DB_PASS")
+	viper.BindEnv("db.name", "DB_NAME")
+	viper.BindEnv("smtp.host", "SMTP_HOST")
+	viper.BindEnv("smtp.port", "SMTP_PORT")
+	viper.BindEnv("smtp.secure", "SMTP_SECURE")
+	viper.BindEnv("smtp.identity", "SMTP_IDENTITY")
+	viper.BindEnv("smtp.user", "SMTP_USER")
+	viper.BindEnv("smtp.pass", "SMTP_PASS")
+	viper.BindEnv("smtp.sender", "SMTP_SENDER")
+
+	err := viper.ReadInConfig()
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			log.Fatal(err)
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       COOKIE_SECURE: "false"
       SMTP_SECURE: "false"
       SMTP_HOST: mail
+    volumes:
+      - ./etc:/etc/thunderdome
   db: 
     image: postgres:latest
     restart: always

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,11 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/markbates/pkger v0.10.1
 	github.com/matcornic/hermes/v2 v2.1.0
+	github.com/spf13/viper v1.6.3
 	golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0
 	gopkg.in/yaml.v2 v2.2.5 // indirect
+
 )

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/StevenWeathers/thunderdome-planning-poker/pkg/email"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/securecookie"
+	"github.com/spf13/viper"
 )
 
 // ServerConfig holds server global config values
@@ -42,18 +43,21 @@ type server struct {
 }
 
 func main() {
-	var cookieHashkey = GetEnv("COOKIE_HASHKEY", "strongest-avenger")
+
+	InitConfig()
+
+	var cookieHashkey = viper.GetString("http.cookie_hashkey")
 
 	s := &server{
 		config: &ServerConfig{
-			ListenPort:         GetEnv("PORT", "8080"),
-			AppDomain:          GetEnv("APP_DOMAIN", "thunderdome.dev"),
-			AdminEmail:         GetEnv("ADMIN_EMAIL", ""),
+			ListenPort:         viper.GetString("http.port"),
+			AppDomain:          viper.GetString("http.domain"),
+			AdminEmail:         viper.GetString("admin.email"),
 			FrontendCookieName: "warrior",
 			SecureCookieName:   "warriorId",
-			SecureCookieFlag:   GetBoolEnv("COOKIE_SECURE", true),
-			AnalyticsEnabled:   GetBoolEnv("ANALYTICS_ENABLED", true),
-			AnalyticsID:        GetEnv("ANALYTICS_ID", "UA-140245309-1"),
+			SecureCookieFlag:   viper.GetBool("http.secure_cookie"),
+			AnalyticsEnabled:   viper.GetBool("analytics.enabled"),
+			AnalyticsID:        viper.GetString("analytics.id"),
 		},
 		router: mux.NewRouter(),
 		cookie: securecookie.New([]byte(cookieHashkey), nil),

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -11,6 +11,8 @@ import (
 	_ "github.com/lib/pq" // necessary for postgres
 	"github.com/markbates/pkger"
 	"golang.org/x/crypto/bcrypt"
+	"github.com/spf13/viper"
+
 )
 
 // HashAndSalt takes a password byte and salt + hashes it
@@ -93,11 +95,11 @@ func New(AdminEmail string) *Database {
 	var d = &Database{
 		// read environment variables and sets up database configuration values
 		config: &Config{
-			host:     GetEnv("DB_HOST", "db"),
-			port:     GetIntEnv("DB_PORT", 5432),
-			user:     GetEnv("DB_USER", "thor"),
-			password: GetEnv("DB_PASS", "odinson"),
-			dbname:   GetEnv("DB_NAME", "thunderdome"),
+			host:     viper.GetString("db.host"),
+			port:     viper.GetInt("db.port"),
+			user:     viper.GetString("db.user"),
+			password: viper.GetString("db.pass"),
+			dbname:   viper.GetString("db.name"),
 		},
 	}
 

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/matcornic/hermes/v2"
+	"github.com/spf13/viper"
 )
 
 // smtpServer data to smtp server
@@ -95,13 +96,13 @@ func New(AppDomain string) *Email {
 		config: &Config{
 			AppDomain:    AppDomain,
 			SenderName:   "Thunderdome",
-			smtpHost:     GetEnv("SMTP_HOST", "localhost"),
-			smtpPort:     GetEnv("SMTP_PORT", "25"),
-			smtpSecure:   GetBoolEnv("SMTP_SECURE", true),
-			smtpIdentity: GetEnv("SMTP_IDENTITY", ""),
-			smtpUser:     GetEnv("SMTP_USER", ""),
-			smtpPass:     GetEnv("SMTP_PASS", ""),
-			smtpSender:   GetEnv("SMTP_SENDER", "no-reply@thunderdome.dev"),
+			smtpHost:     viper.GetString("smtp.host"),
+			smtpPort:     viper.GetString("smtp.port"),
+			smtpSecure:   viper.GetBool("smtp.secure"),
+			smtpIdentity: viper.GetString("smtp.identity"),
+			smtpUser:     viper.GetString("smtp.user"),
+			smtpPass:     viper.GetString("smtp.pass"),
+			smtpSender:   viper.GetString("smtp.sender"),
 		},
 	}
 


### PR DESCRIPTION
I've tried implementing issue #43 adding support for using Viper as configuration library.

The changes are backwards compatible, so the environment variables may still be used as before.

I've implemented the config variable lookup as simple calls to viper all over the place.  I'm not sure what your preference is here.  They could certainly also be read into a (bigger) configuration structure at the start to keep the viper calls at one single location.

Let me know what you think.

Oh, I don't really know go, so expect some newbie go errors.