### PR TITLE
Make allowed points configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following configuration options exists:
 | `smtp.secure`              | SMTP_SECURE          | Set to authenticate with the Smtp server.  |
 | `smtp.identity`            | SMTP_IDENTITY        | Smtp server authorization identity.  Usually unset. |
 | `smtp.sender`              | SMTP_SENDER          | From address in emails sent by Thunderdome.|
+| `config.allowedPointValues` |                     | List of available point values for creating battles. |
 
 
 # Let the Pointing Battles begin!

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following configuration options exists:
 | `smtp.identity`            | SMTP_IDENTITY        | Smtp server authorization identity.  Usually unset. |
 | `smtp.sender`              | SMTP_SENDER          | From address in emails sent by Thunderdome.|
 | `config.allowedPointValues` |                     | List of available point values for creating battles. |
+| `config.defaultPointValues` |                     | List of default selected points for new battles. |
 
 
 # Let the Pointing Battles begin!

--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ func InitConfig() {
 	viper.SetDefault("smtp.port", "25")
 	viper.SetDefault("smtp.secure", true)
 	viper.SetDefault("smtp.sender", "no-reply@thunderdome.dev")
+	viper.SetDefault("config.allowedPointValues", 
+		[]string{"0.5", "1", "2", "3", "5", "8", "13", "20", "30", "50", "?"})
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")

--- a/config.go
+++ b/config.go
@@ -29,7 +29,9 @@ func InitConfig() {
 	viper.SetDefault("smtp.secure", true)
 	viper.SetDefault("smtp.sender", "no-reply@thunderdome.dev")
 	viper.SetDefault("config.allowedPointValues", 
-		[]string{"0.5", "1", "2", "3", "5", "8", "13", "20", "30", "50", "?"})
+		[]string{"0", "1/2", "1", "2", "3", "5", "8", "13", "20", "40", "100", "?"})
+	viper.SetDefault("config.defaultPointValues",
+		[]string{"1", "2", "3", "5", "8", "13", "?" })
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -29,5 +29,8 @@
 		gtag('config', '{{.AnalyticsID}}');
 		</script>
 		{{end}}
+		<script>
+		appConfig = {{ .AppConfig }}
+		</script>
 	</body>
 </html>

--- a/frontend/src/components/CreateBattle.svelte
+++ b/frontend/src/components/CreateBattle.svelte
@@ -11,29 +11,14 @@
     export let router
     export let xfetch
 
-    let possiblePointValues = [
-        '0',
-        '1/2',
-        '1',
-        '2',
-        '3',
-        '5',
-        '8',
-        '13',
-        '20',
-        '40',
-        '100',
-        '?',
-    ]
+    const allowedPointValues = appConfig.AllowedPointValues
 
+    let points = appConfig.DefaultPointValues
     let battleName = ''
-    let points = ['1', '2', '3', '5', '8', '13', '?']
     let plans = []
 
     let checkedPointColor = 'border-green-500 bg-green-100 text-green-600'
     let uncheckedPointColor = 'border-gray-300 bg-white'
-
-    getPossiblePointValues()
 
     function addPlan() {
         plans.unshift({
@@ -52,7 +37,7 @@
     function createBattle(e) {
         e.preventDefault()
 
-        const pointValuesAllowed = possiblePointValues.filter(pv => {
+        const pointValuesAllowed = allowedPointValues.filter(pv => {
             return points.includes(pv)
         })
 
@@ -73,17 +58,6 @@
                 notifications.danger('Error encountered creating battle')
                 eventTag('create_battle', 'engagement', 'failure')
             })
-    }
-
-    function getPossiblePointValues() {
-        xfetch('/api/config/allowedPointValues')
-                .then(res => res.json())
-                .then(function(pa) {
-                        possiblePointValues = pa['Value']
-                })
-                .catch(function(error) {
-                        notifications.danger("Error encountered fetching points allowed")
-                })
     }
 
     onMount(() => {
@@ -118,7 +92,7 @@
             Allowed Point Values
         </h3>
         <div class="control relative -mr-2 md:-mr-1">
-            {#each possiblePointValues as point, pi}
+            {#each allowedPointValues as point, pi}
                 <label
                     class="{points.includes(point) ? checkedPointColor : uncheckedPointColor}
                     cursor-pointer font-bold border p-2 mr-2 xl:mr-1 mb-2

--- a/frontend/src/components/CreateBattle.svelte
+++ b/frontend/src/components/CreateBattle.svelte
@@ -11,7 +11,7 @@
     export let router
     export let xfetch
 
-    const possiblePointValues = [
+    let possiblePointValues = [
         '0',
         '1/2',
         '1',
@@ -32,6 +32,8 @@
 
     let checkedPointColor = 'border-green-500 bg-green-100 text-green-600'
     let uncheckedPointColor = 'border-gray-300 bg-white'
+
+    getPossiblePointValues()
 
     function addPlan() {
         plans.unshift({
@@ -71,6 +73,17 @@
                 notifications.danger('Error encountered creating battle')
                 eventTag('create_battle', 'engagement', 'failure')
             })
+    }
+
+    function getPossiblePointValues() {
+        xfetch('/api/config/allowedPointValues')
+                .then(res => res.json())
+                .then(function(pa) {
+                        possiblePointValues = pa['Value']
+                })
+                .catch(function(error) {
+                        notifications.danger("Error encountered fetching points allowed")
+                })
     }
 
     onMount(() => {

--- a/routes.go
+++ b/routes.go
@@ -13,8 +13,6 @@ func (s *server) routes() {
 	s.router.PathPrefix("/js/").Handler(staticHandler)
 	s.router.PathPrefix("/img/").Handler(staticHandler)
 	// api (currently internal to UI application)
-	// config
-	s.router.HandleFunc("/api/config/{item}", s.handleReadConfig()).Methods("GET")
 	// warrior authentication, profile
 	s.router.HandleFunc("/api/auth", s.handleLogin()).Methods("POST")
 	s.router.HandleFunc("/api/auth/logout", s.handleLogout()).Methods("POST")

--- a/routes.go
+++ b/routes.go
@@ -13,6 +13,8 @@ func (s *server) routes() {
 	s.router.PathPrefix("/js/").Handler(staticHandler)
 	s.router.PathPrefix("/img/").Handler(staticHandler)
 	// api (currently internal to UI application)
+	// config
+	s.router.HandleFunc("/api/config/{item}", s.handleReadConfig()).Methods("GET")
 	// warrior authentication, profile
 	s.router.HandleFunc("/api/auth", s.handleLogin()).Methods("POST")
 	s.router.HandleFunc("/api/auth/logout", s.handleLogout()).Methods("POST")


### PR DESCRIPTION
The set of allowed points supported by Thunderdome seems to be quite common, but it really hurts my eyes, as the fibonacci sequence is broken after 13!

So here's a pull request making the list of allowed point values configurable.

I've not used Svelte before, but it seems to work.

I'm not sure about the interface for reading config values over REST, I ended up with a generic interface for request a single config item, and then mapping that item to a viper config.  This way it's easy to control which config values are available over REST.  Another option would be to allow fetching a bigger config structure that contains all frontend related config values.

I'm happy to change the pull request on your request.