### PR TITLE
Add different avatar services

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,22 @@ The following configuration options exists:
 | `config.allowedPointValues` | CONFIG_POINTS_ALLOWED | List of available point values for creating battles. |
 | `config.defaultPointValues` | CONFIG_POINTS_DEFAULT | List of default selected points for new battles. |
 | `config.show_warrior_rank` | CONFIG_SHOW_RANK     | Set to enable an icon showing the rank of a warrior during battle. |
-| `config.avatar_service`    | CONFIG_AVATAR_SERVICE | Avatar service used, possible values are:<br> + '[default](http://api.adorable.io/avatars/avatar.png)'<br> + '[dicebear](https://avatars.dicebear.com/)' (select sprites in profile) |
+| `config.avatar_service`    | CONFIG_AVATAR_SERVICE | Avatar service used, possible values see next paragraph |
+
+## Avatar Service configuration
+
+Use the name from table below to configure a service - if not set, `default` is used. Each service provides further options which then can be configured by a warrior on the profile page. Once a service is configured, drop downs with the different sprites get available. The table shows all supported services and their sprites. In all cases the same ID (`ead26688-5148-4f3c-a35d-1b0117b4f2a9`) has been used creating the avatars.
+
+| Name |           |           |           |           |           |           |           |           |           |
+| ---------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+| `default`  |           |           |           |           |           |           |           |           |           |
+|            | ![image](https://api.adorable.io/avatars/48/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png) |
+| `dicebear` | male | female | human | identicon | bottts | avataaars | jdenticon | gridy | code |
+|            | ![image](https://avatars.dicebear.com/api/male/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/female/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/human/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/identicon/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/bottts/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/avataaars/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/jdenticon/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/gridy/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/code/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) |
+| `gravatar` | mp | identicon | monsterid | wavatar | retro | robohash | | | |
+|            | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=mp&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=identicon&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=monsterid&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=wavatar&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=retro&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=robohash&r=g) | | | |
+| `robohash` | set1 | set2 | set3 | set4 |
+|            | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set1&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set2&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set3&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set4&size=48x48) |
 
 # Let the Pointing Battles begin!
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following configuration options exists:
 | `config.allowedPointValues` | CONFIG_POINTS_ALLOWED | List of available point values for creating battles. |
 | `config.defaultPointValues` | CONFIG_POINTS_DEFAULT | List of default selected points for new battles. |
 | `config.show_warrior_rank` | CONFIG_SHOW_RANK     | Set to enable an icon showing the rank of a warrior during battle. |
-
+| `config.avatar_service`    | CONFIG_AVATAR_SERVICE | Avatar service used, possible values are:<br> + '[default](http://api.adorable.io/avatars/avatar.png)'<br> + '[dicebear](https://avatars.dicebear.com/)' (select sprites in profile) |
 
 # Let the Pointing Battles begin!
 

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ func InitConfig() {
 	viper.SetDefault("config.defaultPointValues",
 		[]string{"1", "2", "3", "5", "8", "13", "?"})
 	viper.SetDefault("config.show_warrior_rank", false)
+	viper.SetDefault("config.avatar_service", "default")
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")
@@ -57,6 +58,7 @@ func InitConfig() {
 	viper.BindEnv("config.allowedPointValues", "CONFIG_POINTS_ALLOWED")
 	viper.BindEnv("config.defaultPointValues", "CONFIG_POINTS_DEFAULT")
 	viper.BindEnv("config.show_warrior_rank", "CONFIG_SHOW_RANK")
+	viper.BindEnv("config.avatar_service", "CONFIG_AVATAR_SERVICE")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/frontend/src/components/WarriorCard.svelte
+++ b/frontend/src/components/WarriorCard.svelte
@@ -17,10 +17,14 @@
     let nameStyleClass = showRank ? "text-lg" : "text-xl"
 
     const avatar_service = appConfig.AvatarService
-    let avatar_img;
+    let avatar_img
 
     if (avatar_service == 'dicebear') {
-        avatar_img = "https://avatars.dicebear.com/api/" + warrior.sprites + "/" + warrior.id + ".svg?w=48"
+        avatar_img = "https://avatars.dicebear.com/api/" + warrior.avatar + "/" + warrior.id + ".svg?w=48"
+    } else if (avatar_service == 'gravatar') {
+        avatar_img = "https://gravatar.com/avatar/" + warrior.id + "?s=48&d=" + warrior.avatar + "&r=g"
+    } else if (avatar_service == 'robohash') {
+        avatar_img = "https://robohash.org/" + warrior.id + ".png?set=" + warrior.avatar + "&size=48x48"
     } else {
         avatar_img = "https://api.adorable.io/avatars/48/" + warrior.id + ".png"
     }

--- a/frontend/src/components/WarriorCard.svelte
+++ b/frontend/src/components/WarriorCard.svelte
@@ -16,6 +16,15 @@
     const showRank = appConfig.ShowWarriorRank
     let nameStyleClass = showRank ? "text-lg" : "text-xl"
 
+    const avatar_service = appConfig.AvatarService
+    let avatar_img;
+
+    if (avatar_service == 'dicebear') {
+        avatar_img = "https://avatars.dicebear.com/api/" + warrior.sprites + "/" + warrior.id + ".svg?w=48"
+    } else {
+        avatar_img = "https://api.adorable.io/avatars/48/" + warrior.id + ".png"
+    }
+
     function promoteLeader() {
         sendSocketEvent('promote_leader', warrior.id)
         eventTag('promote_leader', 'battle', '')
@@ -31,9 +40,9 @@
     class="border-b border-gray-500 p-4 flex items-center"
     data-testId="warriorCard"
     data-warriorName="{warrior.name}">
-    <div class="w-1/4">
+    <div class="w-1/4" style="margin-right: 5px;">
         <img
-            src="https://api.adorable.io/avatars/48/{warrior.id}.png"
+            src="{avatar_img}"
             alt="Placeholder Avatar" />
     </div>
     <div class="w-3/4">

--- a/frontend/src/pages/WarriorProfile.svelte
+++ b/frontend/src/pages/WarriorProfile.svelte
@@ -17,6 +17,19 @@
     let warriorPassword1 = ''
     let warriorPassword2 = ''
 
+    const avatar_service = appConfig.AvatarService
+    let sprites = [ 
+        "male",
+        "female",
+        "human",
+        "identicon",
+        "bottts",
+        "avataaars",
+        "jdenticon",
+        "gridy",
+        "code"
+    ]
+
     function toggleUpdatePassword() {
         updatePassword = !updatePassword
         eventTag(
@@ -40,6 +53,7 @@
         e.preventDefault()
         const body = {
             warriorName: warriorProfile.name,
+            warriorSprites: warriorProfile.sprites,
         }
         const validName = validateName(body.warriorName)
 
@@ -59,6 +73,7 @@
                         name: warriorProfile.name,
                         email: warriorProfile.email,
                         rank: warriorProfile.rank,
+                        sprites: warriorProfile.sprites,
                     })
 
                     notifications.success('Profile updated.', 1500)
@@ -176,6 +191,34 @@
                             type="email"
                             disabled />
                     </div>
+
+                    {#if avatar_service == 'dicebear'}
+                    <div class="mb-4">
+                        <label
+                            class="block text-gray-700 text-sm font-bold mb-2"
+                            for="yourSprites">
+                            Avatar Sprites
+                        </label>
+                        <select
+                            bind:value="{warriorProfile.sprites}"
+                            class="bg-gray-200 border-gray-200 border-2
+                            appearance-none rounded w-3/4 py-2 px-3
+                            text-gray-700 leading-tight focus:outline-none
+                            cursor-not-allowed"
+                            id="yourSprites"
+                            name="yourSprites">
+                            {#each sprites as sprite}
+                            <option value="{sprite}">{sprite}</option>
+                            {/each}
+                        </select>
+                        <span
+                            class="ml-1"
+                            style="float: right;">
+                            <img src="https://avatars.dicebear.com/api/{warriorProfile.sprites}/{warriorProfile.id}.svg?w=40"
+                                alt="Placeholder Avatar" />
+                        </span>
+                    </div>
+                    {/if}
 
                     <div>
                         <div class="text-right">

--- a/frontend/src/pages/WarriorProfile.svelte
+++ b/frontend/src/pages/WarriorProfile.svelte
@@ -18,17 +18,37 @@
     let warriorPassword2 = ''
 
     const avatar_service = appConfig.AvatarService
-    let sprites = [ 
-        "male",
-        "female",
-        "human",
-        "identicon",
-        "bottts",
-        "avataaars",
-        "jdenticon",
-        "gridy",
-        "code"
-    ]
+    let avatars
+
+    if (avatar_service == 'dicebear') {
+        avatars = [
+            "male",
+            "female",
+            "human",
+            "identicon",
+            "bottts",
+            "avataaars",
+            "jdenticon",
+            "gridy",
+            "code",
+        ]
+    } else if (avatar_service == 'gravatar') {
+        avatars = [
+            "mp",
+            "identicon",
+            "monsterid",
+            "wavatar",
+            "retro",
+            "robohash",
+        ]
+    } else if (avatar_service == 'robohash') {
+        avatars = [
+            "set1",
+            "set2",
+            "set3",
+            "set4",
+        ]
+    }
 
     function toggleUpdatePassword() {
         updatePassword = !updatePassword
@@ -53,7 +73,7 @@
         e.preventDefault()
         const body = {
             warriorName: warriorProfile.name,
-            warriorSprites: warriorProfile.sprites,
+            warriorAvatar: warriorProfile.avatar,
         }
         const validName = validateName(body.warriorName)
 
@@ -73,7 +93,7 @@
                         name: warriorProfile.name,
                         email: warriorProfile.email,
                         rank: warriorProfile.rank,
-                        sprites: warriorProfile.sprites,
+                        avatar: warriorProfile.avatar,
                     })
 
                     notifications.success('Profile updated.', 1500)
@@ -192,30 +212,38 @@
                             disabled />
                     </div>
 
-                    {#if avatar_service == 'dicebear'}
+                    {#if avatar_service == 'dicebear' || avatar_service == 'gravatar' || avatar_service == 'robohash' }
                     <div class="mb-4">
                         <label
                             class="block text-gray-700 text-sm font-bold mb-2"
-                            for="yourSprites">
-                            Avatar Sprites
+                            for="yourAvatar">
+                            Avatar Service Specifc Option
                         </label>
                         <select
-                            bind:value="{warriorProfile.sprites}"
+                            bind:value="{warriorProfile.avatar}"
                             class="bg-gray-200 border-gray-200 border-2
                             appearance-none rounded w-3/4 py-2 px-3
                             text-gray-700 leading-tight focus:outline-none
                             cursor-not-allowed"
-                            id="yourSprites"
-                            name="yourSprites">
-                            {#each sprites as sprite}
-                            <option value="{sprite}">{sprite}</option>
+                            id="yourAvatar"
+                            name="yourAvatar">
+                            {#each avatars as item}
+                            <option value="{item}">{item}</option>
                             {/each}
                         </select>
                         <span
                             class="ml-1"
                             style="float: right;">
-                            <img src="https://avatars.dicebear.com/api/{warriorProfile.sprites}/{warriorProfile.id}.svg?w=40"
+                            {#if avatar_service == 'dicebear'}
+                            <img src="https://avatars.dicebear.com/api/{warriorProfile.avatar}/{warriorProfile.id}.svg?w=40"
                                 alt="Placeholder Avatar" />
+                            {:else if avatar_service == 'gravatar'}
+                            <img src="https://gravatar.com/avatar/{warriorProfile.id}?s=40&d={warriorProfile.avatar}&r=g"
+                                alt="Placeholder Avatar" />
+                            {:else if avatar_service == 'robohash'}
+                            <img src="https://robohash.org/{warriorProfile.id}.png?set={warriorProfile.avatar}&size=40x40"
+                                alt="Placeholder Avatar" />
+                            {/if}
                         </span>
                     </div>
                     {/if}

--- a/handlers.go
+++ b/handlers.go
@@ -164,6 +164,7 @@ func (s *server) handleIndex() http.HandlerFunc {
 		AllowedPointValues []string
 		DefaultPointValues []string
 		ShowWarriorRank    bool
+		AvatarService      string
 	}
 	type UIConfig struct {
 		AnalyticsEnabled bool
@@ -195,6 +196,7 @@ func (s *server) handleIndex() http.HandlerFunc {
 		AllowedPointValues: viper.GetStringSlice("config.allowedPointValues"),
 		DefaultPointValues: viper.GetStringSlice("config.defaultPointValues"),
 		ShowWarriorRank:    viper.GetBool("config.show_warrior_rank"),
+		AvatarService:      viper.GetString("config.avatar_service"),
 	}
 
 	data := UIConfig{
@@ -530,6 +532,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 		keyVal := make(map[string]string)
 		json.Unmarshal(body, &keyVal) // check for errors
 		WarriorName := keyVal["warriorName"]
+		WarriorSprites := keyVal["warriorSprites"]
 
 		WarriorID := vars["id"]
 		warriorCookieID, cookieErr := s.validateWarriorCookie(w, r)
@@ -538,7 +541,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 			return
 		}
 
-		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName)
+		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName, WarriorSprites)
 		if updateErr != nil {
 			log.Println("error attempting to update warrior profile : " + updateErr.Error() + "\n")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/handlers.go
+++ b/handlers.go
@@ -532,7 +532,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 		keyVal := make(map[string]string)
 		json.Unmarshal(body, &keyVal) // check for errors
 		WarriorName := keyVal["warriorName"]
-		WarriorSprites := keyVal["warriorSprites"]
+		WarriorAvatar := keyVal["warriorAvatar"]
 
 		WarriorID := vars["id"]
 		warriorCookieID, cookieErr := s.validateWarriorCookie(w, r)
@@ -541,7 +541,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 			return
 		}
 
-		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName, WarriorSprites)
+		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName, WarriorAvatar)
 		if updateErr != nil {
 			log.Println("error attempting to update warrior profile : " + updateErr.Error() + "\n")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/database/battles.go
+++ b/pkg/database/battles.go
@@ -165,7 +165,7 @@ func (d *Database) GetBattleWarrior(BattleID string, WarriorID string) (*BattleW
 
 	e := d.db.QueryRow(
 		`SELECT
-			w.id, w.name, w.rank, w.dicebear_sprites, coalesce(bw.active, FALSE)
+			w.id, w.name, w.rank, w.avatar, coalesce(bw.active, FALSE)
 		FROM warriors w
 		LEFT JOIN battles_warriors bw ON bw.warrior_id = w.id AND bw.battle_id = $1
 		WHERE id = $2`,
@@ -175,7 +175,7 @@ func (d *Database) GetBattleWarrior(BattleID string, WarriorID string) (*BattleW
 		&w.WarriorID,
 		&w.WarriorName,
 		&w.WarriorRank,
-		&w.WarriorSprites,
+		&w.WarriorAvatar,
 		&active,
 	)
 	if e != nil {
@@ -195,7 +195,7 @@ func (d *Database) GetBattleWarriors(BattleID string) []*BattleWarrior {
 	var warriors = make([]*BattleWarrior, 0)
 	rows, err := d.db.Query(
 		`SELECT
-			w.id, w.name, w.rank, w.dicebear_sprites, bw.active
+			w.id, w.name, w.rank, w.avatar, bw.active
 		FROM battles_warriors bw
 		LEFT JOIN warriors w ON bw.warrior_id = w.id
 		WHERE bw.battle_id = $1
@@ -206,7 +206,7 @@ func (d *Database) GetBattleWarriors(BattleID string) []*BattleWarrior {
 		defer rows.Close()
 		for rows.Next() {
 			var w BattleWarrior
-			if err := rows.Scan(&w.WarriorID, &w.WarriorName, &w.WarriorRank, &w.WarriorSprites, &w.Active); err != nil {
+			if err := rows.Scan(&w.WarriorID, &w.WarriorName, &w.WarriorRank, &w.WarriorAvatar, &w.Active); err != nil {
 				log.Println(err)
 			} else {
 				warriors = append(warriors, &w)

--- a/pkg/database/battles.go
+++ b/pkg/database/battles.go
@@ -165,7 +165,7 @@ func (d *Database) GetBattleWarrior(BattleID string, WarriorID string) (*BattleW
 
 	e := d.db.QueryRow(
 		`SELECT
-			w.id, w.name, w.rank, coalesce(bw.active, FALSE)
+			w.id, w.name, w.rank, w.dicebear_sprites, coalesce(bw.active, FALSE)
 		FROM warriors w
 		LEFT JOIN battles_warriors bw ON bw.warrior_id = w.id AND bw.battle_id = $1
 		WHERE id = $2`,
@@ -175,6 +175,7 @@ func (d *Database) GetBattleWarrior(BattleID string, WarriorID string) (*BattleW
 		&w.WarriorID,
 		&w.WarriorName,
 		&w.WarriorRank,
+		&w.WarriorSprites,
 		&active,
 	)
 	if e != nil {
@@ -194,7 +195,7 @@ func (d *Database) GetBattleWarriors(BattleID string) []*BattleWarrior {
 	var warriors = make([]*BattleWarrior, 0)
 	rows, err := d.db.Query(
 		`SELECT
-			w.id, w.name, w.rank, bw.active
+			w.id, w.name, w.rank, w.dicebear_sprites, bw.active
 		FROM battles_warriors bw
 		LEFT JOIN warriors w ON bw.warrior_id = w.id
 		WHERE bw.battle_id = $1
@@ -205,7 +206,7 @@ func (d *Database) GetBattleWarriors(BattleID string) []*BattleWarrior {
 		defer rows.Close()
 		for rows.Next() {
 			var w BattleWarrior
-			if err := rows.Scan(&w.WarriorID, &w.WarriorName, &w.WarriorRank, &w.Active); err != nil {
+			if err := rows.Scan(&w.WarriorID, &w.WarriorName, &w.WarriorRank, &w.WarriorSprites, &w.Active); err != nil {
 				log.Println(err)
 			} else {
 				warriors = append(warriors, &w)

--- a/pkg/database/types.go
+++ b/pkg/database/types.go
@@ -22,10 +22,11 @@ type Database struct {
 
 // BattleWarrior aka user
 type BattleWarrior struct {
-	WarriorID   string `json:"id"`
-	WarriorName string `json:"name"`
-	WarriorRank string `json:"rank"`
-	Active      bool   `json:"active"`
+	WarriorID      string `json:"id"`
+	WarriorName    string `json:"name"`
+	WarriorRank    string `json:"rank"`
+	WarriorSprites string `json:"sprites"`
+	Active         bool   `json:"active"`
 }
 
 // Battle aka arena
@@ -42,11 +43,12 @@ type Battle struct {
 
 // Warrior aka user
 type Warrior struct {
-	WarriorID    string `json:"id"`
-	WarriorName  string `json:"name"`
-	WarriorEmail string `json:"email"`
-	WarriorRank  string `json:"rank"`
-	Verified     bool   `json:"verified"`
+	WarriorID      string `json:"id"`
+	WarriorName    string `json:"name"`
+	WarriorEmail   string `json:"email"`
+	WarriorRank    string `json:"rank"`
+	WarriorSprites string `json:"sprites"`
+	Verified       bool   `json:"verified"`
 }
 
 // Vote structure

--- a/pkg/database/types.go
+++ b/pkg/database/types.go
@@ -22,11 +22,11 @@ type Database struct {
 
 // BattleWarrior aka user
 type BattleWarrior struct {
-	WarriorID      string `json:"id"`
-	WarriorName    string `json:"name"`
-	WarriorRank    string `json:"rank"`
-	WarriorSprites string `json:"sprites"`
-	Active         bool   `json:"active"`
+	WarriorID     string `json:"id"`
+	WarriorName   string `json:"name"`
+	WarriorRank   string `json:"rank"`
+	WarriorAvatar string `json:"avatar"`
+	Active        bool   `json:"active"`
 }
 
 // Battle aka arena
@@ -43,12 +43,12 @@ type Battle struct {
 
 // Warrior aka user
 type Warrior struct {
-	WarriorID      string `json:"id"`
-	WarriorName    string `json:"name"`
-	WarriorEmail   string `json:"email"`
-	WarriorRank    string `json:"rank"`
-	WarriorSprites string `json:"sprites"`
-	Verified       bool   `json:"verified"`
+	WarriorID     string `json:"id"`
+	WarriorName   string `json:"name"`
+	WarriorEmail  string `json:"email"`
+	WarriorRank   string `json:"rank"`
+	WarriorAvatar string `json:"avatar"`
+	Verified      bool   `json:"verified"`
 }
 
 // Vote structure

--- a/pkg/database/warriors.go
+++ b/pkg/database/warriors.go
@@ -12,14 +12,14 @@ func (d *Database) GetWarrior(WarriorID string) (*Warrior, error) {
 	var warriorEmail sql.NullString
 
 	e := d.db.QueryRow(
-		"SELECT id, name, email, rank, dicebear_sprites, verified FROM warriors WHERE id = $1",
+		"SELECT id, name, email, rank, avatar, verified FROM warriors WHERE id = $1",
 		WarriorID,
 	).Scan(
 		&w.WarriorID,
 		&w.WarriorName,
 		&warriorEmail,
 		&w.WarriorRank,
-		&w.WarriorSprites,
+		&w.WarriorAvatar,
 		&w.Verified,
 	)
 	if e != nil {
@@ -38,14 +38,14 @@ func (d *Database) AuthWarrior(WarriorEmail string, WarriorPassword string) (*Wa
 	var passHash string
 
 	e := d.db.QueryRow(
-		`SELECT id, name, email, rank, password, dicebear_sprites, verified FROM warriors WHERE email = $1`,
+		`SELECT id, name, email, rank, password, avatar, verified FROM warriors WHERE email = $1`,
 		WarriorEmail,
 	).Scan(
 		&w.WarriorID,
 		&w.WarriorName,
 		&w.WarriorEmail,
 		&w.WarriorRank,
-		&w.WarriorSprites,
+		&w.WarriorAvatar,
 		&passHash,
 		&w.Verified,
 	)
@@ -70,7 +70,7 @@ func (d *Database) CreateWarriorPrivate(WarriorName string) (*Warrior, error) {
 		return nil, errors.New("unable to create new warrior")
 	}
 
-	return &Warrior{WarriorID: WarriorID, WarriorName: WarriorName, WarriorSprites: "identicon"}, nil
+	return &Warrior{WarriorID: WarriorID, WarriorName: WarriorName, WarriorAvatar: "identicon"}, nil
 }
 
 // CreateWarriorCorporal adds a new warrior corporal (registered) to the db
@@ -83,7 +83,7 @@ func (d *Database) CreateWarriorCorporal(WarriorName string, WarriorEmail string
 	var WarriorID string
 	var verifyID string
 	WarriorRank := "CORPORAL"
-	WarriorSprites := "identicon"
+	WarriorAvatar := "identicon"
 
 	if ActiveWarriorID != "" {
 		e := d.db.QueryRow(
@@ -112,19 +112,19 @@ func (d *Database) CreateWarriorCorporal(WarriorName string, WarriorEmail string
 		}
 	}
 
-	return &Warrior{WarriorID: WarriorID, WarriorName: WarriorName, WarriorEmail: WarriorEmail, WarriorRank: WarriorRank, WarriorSprites: WarriorSprites}, verifyID, nil
+	return &Warrior{WarriorID: WarriorID, WarriorName: WarriorName, WarriorEmail: WarriorEmail, WarriorRank: WarriorRank, WarriorAvatar: WarriorAvatar}, verifyID, nil
 }
 
 // UpdateWarriorProfile attempts to update the warriors profile
-func (d *Database) UpdateWarriorProfile(WarriorID string, WarriorName string, WarriorSprites string) error {
-	if WarriorSprites == "" {
-		WarriorSprites = "identicon"
+func (d *Database) UpdateWarriorProfile(WarriorID string, WarriorName string, WarriorAvatar string) error {
+	if WarriorAvatar == "" {
+		WarriorAvatar = "identicon"
 	}
 	if _, err := d.db.Exec(
-		`UPDATE warriors SET name = $2, dicebear_sprites = $3 WHERE id = $1;`,
+		`UPDATE warriors SET name = $2, avatar = $3 WHERE id = $1;`,
 		WarriorID,
 		WarriorName,
-		WarriorSprites,
+		WarriorAvatar,
 	); err != nil {
 		log.Println(err)
 		return errors.New("error attempting to update warriors profile")

--- a/schema.sql
+++ b/schema.sql
@@ -69,7 +69,7 @@ ALTER TABLE battles ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE plans ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE warriors ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE warriors ADD COLUMN IF NOT EXISTS verified BOOL DEFAULT false;
-ALTER TABLE warriors ADD COLUMN IF NOT EXISTS dicebear_sprites VARCHAR(128) DEFAULT 'identicon';
+ALTER TABLE warriors ADD COLUMN IF NOT EXISTS avatar VARCHAR(128) DEFAULT 'identicon';
 
 --
 -- Types (used in Stored Procedures)

--- a/schema.sql
+++ b/schema.sql
@@ -69,6 +69,7 @@ ALTER TABLE battles ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE plans ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE warriors ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 ALTER TABLE warriors ADD COLUMN IF NOT EXISTS verified BOOL DEFAULT false;
+ALTER TABLE warriors ADD COLUMN IF NOT EXISTS dicebear_sprites VARCHAR(128) DEFAULT 'identicon';
 
 --
 -- Types (used in Stored Procedures)


### PR DESCRIPTION
Our developers did not like the default avatar service used. So I searched a bit and now we use dicebear. 
With the response from #72 I added a configuration item that allows configuration of different services.

Hope you like it.

From the Readme:
8< ---------------------------------------------

## Avatar Service configuration

Use the name from table below to configure a service - if not set, `default` is used. Each service provides further options which then can be configured by a warrior on the profile page. Once a service is configured, drop downs with the different sprites get available. The table shows all supported services and their sprites. In all cases the same ID (`ead26688-5148-4f3c-a35d-1b0117b4f2a9`) has been used creating the avatars.

| Name |           |           |           |           |           |           |           |           |           |
| ---------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
| `default`  |           |           |           |           |           |           |           |           |           |
|            | ![image](https://api.adorable.io/avatars/48/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png) |
| `dicebear` | male | female | human | identicon | bottts | avataaars | jdenticon | gridy | code |
|            | ![image](https://avatars.dicebear.com/api/male/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/female/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/human/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/identicon/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/bottts/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/avataaars/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/jdenticon/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/gridy/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) | ![image](https://avatars.dicebear.com/api/code/ead26688-5148-4f3c-a35d-1b0117b4f2a9.svg?w=48) |
| `gravatar` | mp | identicon | monsterid | wavatar | retro | robohash | | | |
|            | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=mp&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=identicon&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=monsterid&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=wavatar&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=retro&r=g) | ![image](https://gravatar.com/avatar/ead26688-5148-4f3c-a35d-1b0117b4f2a9?s=48&d=robohash&r=g) | | | |
| `robohash` | set1 | set2 | set3 | set4 |
|            | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set1&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set2&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set3&size=48x48) | ![image](https://robohash.org/ead26688-5148-4f3c-a35d-1b0117b4f2a9.png?set=set4&size=48x48) |


8< ---------------------------------------------
