### PR TITLE
Add import FROM JIRA xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following configuration options exists:
 | `config.toast_timeout`     | CONFIG_TOAST_TIMEOUT | Number of milliseconds before notifications are hidden. | 1000 |
 | `config.allow_guests`     | CONFIG_ALLOW_GUESTS | Whether or not to allow guest (anonymous) users. | true |
 | `config.allow_registration`     | CONFIG_ALLOW_REGISTRAATION | Whether or not to allow user registration (outside Admin). | true |
+| `config.allow_jira_import`     | CONFIG_ALLOW_JIRA_IMPORT | Whether or not to allow import plans from JIRA XML. | false |
 
 ## Avatar Service configuration
 

--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ func InitConfig() {
 	viper.SetDefault("config.toast_timeout", 1000)
 	viper.SetDefault("config.allow_guests", true)
 	viper.SetDefault("config.allow_registration", true)
+	viper.SetDefault("config.allow_jira_import", false)
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")
@@ -73,6 +74,7 @@ func InitConfig() {
 	viper.BindEnv("config.toast_timeout", "CONFIG_TOAST_TIMEOUT")
 	viper.BindEnv("config.allow_guests", "CONFIG_ALLOW_GUESTS")
 	viper.BindEnv("config.allow_registration", "CONFIG_ALLOW_REGISTRATION")
+	viper.BindEnv("config.allow_jira_import", "CONFIG_ALLOW_JIRA_IMPORT")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/frontend/src/components/BattlePlans.svelte
+++ b/frontend/src/components/BattlePlans.svelte
@@ -3,11 +3,13 @@
     import AddPlan from './AddPlan.svelte'
     import HollowButton from './HollowButton.svelte'
     import ViewPlan from './ViewPlan.svelte'
+    import JiraImport from './JiraImport.svelte'
 
     export let plans = []
     export let isLeader = false
     export let sendSocketEvent = () => {}
     export let eventTag
+    export let notifications
 
     let defaultPlan = {
         id: '',
@@ -23,6 +25,8 @@
     let showViewPlan = false
     let selectedPlan = { ...defaultPlan }
     let showCompleted = false
+
+    const allowJiraImport = appConfig.AllowJiraImport
 
     const toggleAddPlan = planId => () => {
         if (planId) {
@@ -82,14 +86,17 @@
 
 <div class="bg-white shadow-lg mb-4 rounded">
     <div class="flex items-center bg-gray-200 p-4 rounded-t">
-        <div class="w-1/2 lg:w-3/4">
+        <div class="w-1/2 lg:w-{allowJiraImport ? '1/2' : '3/4'}">
             <h3 class="text-2xl leading-tight font-bold">Plans</h3>
         </div>
-        <div class="w-1/2 lg:w-1/4 text-right">
+        <div class="w-1/2 lg:w-1/{allowJiraImport ? '2' : '4'} text-right">
             {#if isLeader}
                 <HollowButton color="blue" onClick="{toggleAddPlan()}">
                     Add Plan
                 </HollowButton>
+                {#if allowJiraImport}
+                    <JiraImport {handlePlanAdd} {notifications} />
+                {/if}
             {/if}
         </div>
     </div>

--- a/frontend/src/components/JiraImport.svelte
+++ b/frontend/src/components/JiraImport.svelte
@@ -1,0 +1,75 @@
+<script>
+    import HollowButton from '../components/HollowButton.svelte'
+
+    export let notifications
+    export let handlePlanAdd = () => {}
+
+    let files
+
+    function showDialog () {
+        const fileInput = document.querySelector('[data-jira-import]')
+        if (fileInput) {
+            fileInput.click()
+        }
+    }
+
+    function uploadFile () {
+        let file = this.files[0];
+        if (!file) {
+          return;
+        }
+        if (file.type !== 'text/xml') {
+            notifications.danger(
+                    'Error bad file type',
+            );
+            return;
+        }
+
+        let reader = new FileReader();
+
+        reader.readAsText(file);
+
+        reader.onload = () => {
+          try {
+              const docParser = new DOMParser();
+              const domContent = reader.result.replace(/<!--.*?-->/sig, '');
+              const doc = docParser.parseFromString(domContent, 'application/xml');
+              const items = doc.querySelectorAll('channel>item');
+              if (items) {
+                  for (let i = 0; i < items.length; i++) {
+                      const item = items[i];
+                      const plan = {
+                          id: '',
+                          planName: item.querySelector('summary').innerHTML,
+                          type: item.querySelector('type').innerHTML.toLowerCase(),
+                          referenceId: item.querySelector('key').innerHTML,
+                          link: item.querySelector('link').innerHTML,
+                          description: item.querySelector('description').innerHTML,
+                          acceptanceCriteria: ''
+                      }
+                      handlePlanAdd(plan);
+                  }
+              }
+          } catch (e) {
+              notifications.danger(
+                      'Error reading file',
+              );
+          }
+        }
+
+        reader.onerror = () => {
+            notifications.danger(
+                    'Error reading file',
+            );
+        }
+    }
+</script>
+
+<style>
+    [data-jira-import] {
+        display: none;
+    }
+</style>
+
+<input type="file" on:change="{uploadFile}" data-jira-import/>
+<HollowButton onClick="{showDialog}">Import from JIRA</HollowButton>

--- a/frontend/src/pages/Battle.svelte
+++ b/frontend/src/pages/Battle.svelte
@@ -405,7 +405,8 @@
                     plans="{battle.plans}"
                     isLeader="{battle.leaderId === $warrior.id}"
                     {sendSocketEvent}
-                    {eventTag} />
+                    {eventTag}
+                    {notifications} />
             </div>
 
             <div class="w-full lg:w-1/4 px-4">

--- a/handlers.go
+++ b/handlers.go
@@ -168,6 +168,7 @@ func (s *server) handleIndex() http.HandlerFunc {
 		ToastTimeout       int
 		AllowGuests        bool
 		AllowRegistration  bool
+		AllowJiraImport  bool
 	}
 	type UIConfig struct {
 		AnalyticsEnabled bool
@@ -203,6 +204,7 @@ func (s *server) handleIndex() http.HandlerFunc {
 		ToastTimeout:       viper.GetInt("config.toast_timeout"),
 		AllowGuests:        viper.GetBool("config.allow_guests"),
 		AllowRegistration:  viper.GetBool("config.allow_registration"),
+		AllowJiraImport:  viper.GetBool("config.allow_jira_import"),
 	}
 
 	data := UIConfig{


### PR DESCRIPTION
We use planning poker to evaluate tasks from JIRA. But manual adding plans is laborious. This feature add "Import from JIRA" button. Feature may be enabled by config option and disabled by default. 

JiraImport component render Button and hidden file input. XML parsed with DOMParser. 