### PR TITLE
Make CheckOrigin configurable by adding ALLOWED_ORIGINS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following configuration options exists:
 | `http.port`                | PORT                 | Which port to listen for HTTP connections. | 8080 |
 | `http.secure_cookie`       | COOKIE_SECURE        | Use secure cookies or not.                 | true |
 | `http.domain`              | APP_DOMAIN           | The domain/base URL for this instance of Thunderdome.  Used for creating URLs in emails. | thunderdome.dev |
+| `http.allowed_origins`     | ALLOWED_ORIGINS      | List of comma separated domains. Used to allow origins in websocket communication. | thunderdome.dev |
 | `analytics.enabled`        | ANALYTICS_ENABLED    | Enable/disable google analytics.           | true |
 | `analytics.id`             | ANALYTICS_ID         | Google analytics identifier.               | UA-140245309-1 |
 | `db.host`                  | DB_HOST              | Database host name.                        | db |

--- a/client.go
+++ b/client.go
@@ -300,13 +300,6 @@ func (s *server) serveWs() http.HandlerFunc {
 		vars := mux.Vars(r)
 		battleID := vars["id"]
 
-		// upgrade to WebSocket connection
-		ws, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			log.Println(err)
-			return
-		}
-
 		upgrader.CheckOrigin = func(r *http.Request) bool {
 			if len(s.config.AllowedOrigins) == 0 {
 				return true
@@ -320,6 +313,13 @@ func (s *server) serveWs() http.HandlerFunc {
 			}
 
 			return false
+		}
+
+		// upgrade to WebSocket connection
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Println(err)
+			return
 		}
 
 		// make sure battle is legit

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -304,6 +305,21 @@ func (s *server) serveWs() http.HandlerFunc {
 		if err != nil {
 			log.Println(err)
 			return
+		}
+
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			if len(s.config.AllowedOrigins) == 0 {
+				return true
+			}
+
+			allowedOriginList := strings.Split(s.config.AllowedOrigins, ",")
+			for _, o := range allowedOriginList {
+				if strings.Contains(r.Host, o) {
+					return true
+				}
+			}
+
+			return false
 		}
 
 		// make sure battle is legit

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ func InitConfig() {
 
 	viper.SetDefault("http.cookie_hashkey", "strongest-avenger")
 	viper.SetDefault("http.port", "8080")
+	viper.SetDefault("http.allowed_origins", "thunderdome.dev")
 	viper.SetDefault("http.secure_cookie", true)
 	viper.SetDefault("http.domain", "thunderdome.dev")
 	viper.SetDefault("analytics.enabled", true)
@@ -55,6 +56,7 @@ func InitConfig() {
 	viper.BindEnv("http.port", "PORT")
 	viper.BindEnv("http.secure_cookie", "COOKIE_SECURE")
 	viper.BindEnv("http.domain", "APP_DOMAIN")
+	viper.BindEnv("http.allowed_origins", "ALLOWED_ORIGINS")
 	viper.BindEnv("analytics.enabled", "ANALYTICS_ENABLED")
 	viper.BindEnv("analytics.id", "ANALYTICS_ID")
 	viper.BindEnv("admin.email", "ADMIN_EMAIL")

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ type ServerConfig struct {
 	ListenPort string
 	// the domain of the application for cookie securing
 	AppDomain string
+	// list of allowed origin domains
+	AllowedOrigins string
 	// name of the frontend cookie
 	FrontendCookieName string
 	// name of the warrior cookie
@@ -52,6 +54,7 @@ func main() {
 		config: &ServerConfig{
 			ListenPort:         viper.GetString("http.port"),
 			AppDomain:          viper.GetString("http.domain"),
+			AllowedOrigins:     viper.GetString("http.allowed_origins"),
 			AdminEmail:         viper.GetString("admin.email"),
 			FrontendCookieName: "warrior",
 			SecureCookieName:   "warriorId",


### PR DESCRIPTION
I've deployed the planning poker application on my server and got this error
```websocket: request origin not allowed by Upgrader.CheckOrigin```

I've tried to solve this by making the origin configurable.

