### PR TITLE
Fix routing for enlist

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -8,7 +8,7 @@ const fallbackLocale = appConfig.DefaultLocale
 
 const defaultAppRoutes = {
     landing: '/',
-    enlist: '/enlist',
+    register: '/enlist',
     battles: '/battles',
     battle: '/battle',
     login: '/login',
@@ -19,7 +19,7 @@ const defaultAppRoutes = {
 }
 const friendlyAppRoutes = {
     ...defaultAppRoutes,
-    enlist: '/register',
+    register: '/register',
     battles: '/sessions',
     battle: '/session',
     profile: '/user-profile',


### PR DESCRIPTION
Hi. Bug was appeared after [this commit](https://github.com/StevenWeathers/thunderdome-planning-poker/commit/f06e5670e6f8a5be24bf739f5b56e969299e7ee2). In config variable for the registration route called `enlist` but in other files used `appRoutes.register`. So actions related with registration broke.