### PR TITLE
Fix typos in German language file and change version log message

### DIFF
--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -14,7 +14,7 @@
             "join": "Schlacht beitreten",
             "save": "Speichern",
             "edit": "Schlacht bearbeiten",
-            "editPointsDisabled": "Abstimmung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden."
+            "editPointsDisabled": "Sch\u00E4tzung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden."
         },
         "warrior": {
             "create": "Krieger erstellen",
@@ -30,8 +30,8 @@
             "skip": "Plan \u00FCberspringen",
             "pointed": "Gesch\u00E4tzt ({count})",
             "unpointed": "Ungesch\u00E4tzt ({count})",
-            "finishVoting": "Abstimmung beenden",
-            "restartVoting": "Abstimmung neu starten",
+            "finishVoting": "Sch\u00E4tzung beenden",
+            "restartVoting": "Sch\u00E4tzung neu starten",
             "save": "Speichern",
             "importJiraXML": {
                 "button": "Jira XML Import",
@@ -84,8 +84,8 @@
             "features": {
                 "title": "Eigenschaften",
                 "bullet1": "Keine Beschr\u00E4nkung der Kriegeranzahl einer Schlacht",
-                "bullet2": "Sichere Abstimmung verhindert, dass ein Krieger schummelt",
-                "bullet3": "Abstimmungsergebnisse, die klar und hilfreich sind",
+                "bullet2": "Sichere Sch\u00E4tzung verhindert, dass ein Krieger schummelt",
+                "bullet3": "Sch\u00E4tzungsergebnisse, die klar und hilfreich sind",
                 "bullet4": "M\u00F6glichkeit, jeden Krieger zum Boss zu bef\u00F6rdern",
                 "bullet5": "Anpassbare Punkte-Skalierung",
                 "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Funktionen vorschlagen{contribClose}",
@@ -119,7 +119,7 @@
                         }
                     },
                     "autoFinishVoting": {
-                        "label": "Abstimmung automatisch beenden, wenn alle Krieger gesch\u00E4tzt haben"
+                        "label": "Sch\u00E4tzung automatisch beenden, wenn alle Krieger gesch\u00E4tzt haben"
                     }
                 }
             }
@@ -282,10 +282,10 @@
             "points": "Punkte",
             "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
-                "totalVotes": "Abstimmer",
+                "totalVotes": "Sch\u00E4tzungen",
                 "average": "Durchschnitt",
                 "highest": "H\u00F6chster",
-                "showVoters": "Zeige Abstimmer",
+                "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Krieger"
             }
         }

--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -1,6 +1,6 @@
 {
     "appName": "Thunderdome",
-    "appVersion": "Ausführung {version}",
+    "appVersion": "Version {version}",
     "avatarAltText": "Avatar Platzhalter",
     "actions": {
         "logout": {
@@ -25,11 +25,11 @@
             "add": "Plan hinzuf\u00FCgen",
             "view": "Anzeigen",
             "edit": "Bearbeiten",
-            "delete": "l\u00F6schen",
+            "delete": "L\u00F6schen",
             "activate": "Aktivieren",
             "skip": "Plan \u00FCberspringen",
-            "pointed": "Abgestimmt ({count})",
-            "unpointed": "Offen ({count})",
+            "pointed": "Gesch\u00E4tzt ({count})",
+            "unpointed": "Ungesch\u00E4tzt ({count})",
             "finishVoting": "Abstimmung beenden",
             "restartVoting": "Abstimmung neu starten",
             "save": "Speichern",
@@ -52,8 +52,8 @@
                     "placeholder": "Link zum Plan eingeben"
                 },
                 "referenceId": {
-                    "label": "Referenz-ID",
-                    "placeholder": "Referenz-ID eingeben"
+                    "label": "Referenz ID",
+                    "placeholder": "Referenz ID eingeben"
                 },
                 "description": {
                     "label": "Beschreibung",
@@ -76,19 +76,19 @@
     },
     "pages": {
         "landing": {
-            "title": "Thunderdome ist eine Open Source Agile Planning Poker App mit einer lustigen Thematik",
+            "title": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
             "bullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
-            "bullet2": "Einfache {crossoutOpen}Benutzer{crossoutClose}Krieger Erfahrung",
+            "bullet2": "Einfache {crossoutOpen}Benutzer{crossoutClose}Krieger-Erfahrung",
             "bullet3": "Funktioniert mit allen {mbOpen}modernen Browsern*{mbClose}, inklusive Mobile",
-            "bullet3NotSorry": "*entschuldigung, keine Entschuldigung bei IE",
+            "bullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
             "features": {
-                "title": "Features",
+                "title": "Eigenschaften",
                 "bullet1": "Keine Beschr\u00E4nkung der Kriegeranzahl einer Schlacht",
                 "bullet2": "Sichere Abstimmung verhindert, dass ein Krieger schummelt",
                 "bullet3": "Abstimmungsergebnisse, die klar und hilfreich sind",
                 "bullet4": "M\u00F6glichkeit, jeden Krieger zum Boss zu bef\u00F6rdern",
                 "bullet5": "Anpassbare Punkte-Skalierung",
-                "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Features vorschlagen{contribClose}",
+                "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Funktionen vorschlagen{contribClose}",
                 "bullet7": "Keine Geb\u00FChren und ohne Werbung"
             }
         },
@@ -110,16 +110,16 @@
                     },
                     "plans": {
                         "label": "Pl\u00E4ne",
-                        "addButton": "Plan hinzuf\u00FCgen",
+                        "addButton": "Hinzuf\u00FCgen",
                         "removeButton": "Entfernen",
                         "fields": {
                             "name": {
-                                "placeholder": "Plan Namen eingeben"
+                                "placeholder": "Name f\u00FCr den Plan eingeben"
                             }
                         }
                     },
                     "autoFinishVoting": {
-                        "label": "Abstimmung automatisch beenden, wenn alle Krieger abgegeben haben"
+                        "label": "Abstimmung automatisch beenden, wenn alle Krieger gesch\u00E4tzt haben"
                     }
                 }
             }
@@ -167,7 +167,7 @@
             "loading": "Konto\u00FCberpr\u00FCfung...",
             "verified": {
                 "title": "Konto \u00FCberpr\u00FCft",
-                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail."
+                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail-Adresse."
             },
             "failed": {
                 "title": "\u00DCberpr\u00FCfung fehlgeschlagen",
@@ -195,7 +195,7 @@
                     "label": "Avatar"
                 },
                 "enable_notifications": {
-                    "label": "Enable battle notifications"
+                    "label": "Benachrichtigungen aktivieren"
                 }
             },
             "updatePasswordForm": {
@@ -268,19 +268,19 @@
             "title": "Schlacht",
             "warriors": "Krieger",
             "socketReconnecting": "Ooops, Schlachtpl\u00E4ne werden neu geladen...",
-            "socketError": "Fehler beim Eintritt in die schlacht, bitte aktualisieren und nochmals versuchen.",
+            "socketError": "Fehler beim Eintritt in die Schlacht, bitte aktualisieren und nochmals versuchen.",
             "loading": "Lade Schlachtpl\u00E4ne...",
-            "votingNotStarted": "Votum noch nicht gestartet",
+            "votingNotStarted": "Sch\u00E4tzung noch nicht gestartet",
             "warriorJoined": "{name} hat das Schlachtfeld betreten",
             "warriorRetreated": "{name} hat das Schlachtfeld verlassen",
-            "warriorVoted": "{name} hat ein Votum abegeben",
-            "warriorRetractedVote": "{name} hat das Votum zur\u00FCckgezogen",
-            "warriorNudge": "pst... {name}, wir warten auf ein Votum.",
+            "warriorVoted": "{name} hat eine Sch\u00E4tzung abegeben",
+            "warriorRetractedVote": "{name} hat die Sch\u00E4tzung zur\u00FCckgezogen",
+            "warriorNudge": "pst... {name}, wir warten auf eine Sch\u00E4tzung",
             "warriorInvite": "Krieger einladen",
             "warriorLeader": "Chef",
             "finalPoints": "Finale Punkte",
             "points": "Punkte",
-            "planSkipped": "Plan übersprungen",
+            "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
                 "totalVotes": "Abstimmer",
                 "average": "Durchschnitt",

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -14,7 +14,7 @@
             "join": "Sitzung beitreten",
             "save": "Speichern",
             "edit": "Sitzung bearbeiten",
-            "editPointsDisabled": "Abstimmung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden."
+            "editPointsDisabled": "Sch\u00E4tzung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden."
         },
         "warrior": {
             "create": "Benutzer erstellen",
@@ -30,8 +30,8 @@
             "skip": "Plan \u00FCberspringen",
             "pointed": "Gesch\u00E4tzt ({count})",
             "unpointed": "Ungesch\u00E4tzt ({count})",
-            "finishVoting": "Abstimmung beenden",
-            "restartVoting": "Abstimmung neu starten",
+            "finishVoting": "Sch\u00E4tzung beenden",
+            "restartVoting": "Sch\u00E4tzung neu starten",
             "save": "Speichern",
             "importJiraXML": {
                 "button": "Jira XML Import",
@@ -84,8 +84,8 @@
             "features": {
                 "title": "Eigenschaften",
                 "bullet1": "Keine Beschr\u00E4nkung der Benutzeranzahl einer Sitzung",
-                "bullet2": "Sichere Abstimmung verhindert, dass ein Benutzer schummelt",
-                "bullet3": "Abstimmungsergebnisse, die klar und hilfreich sind",
+                "bullet2": "Sichere Sch\u00E4tzung verhindert, dass ein Benutzer schummelt",
+                "bullet3": "Sch\u00E4tzungsergebnisse, die klar und hilfreich sind",
                 "bullet4": "M\u00F6glichkeit, jeden Benutzer zum Boss zu bef\u00F6rdern",
                 "bullet5": "Anpassbare Punkte-Skalierung",
                 "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Funktionen vorschlagen{contribClose}",
@@ -119,7 +119,7 @@
                         }
                     },
                     "autoFinishVoting": {
-                        "label": "Abstimmung automatisch beenden, wenn alle Benutzer gesch\u00E4tzt haben"
+                        "label": "Sch\u00E4tzung automatisch beenden, wenn alle Benutzer gesch\u00E4tzt haben"
                     }
                 }
             }
@@ -282,10 +282,10 @@
             "points": "Punkte",
             "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
-                "totalVotes": "Abstimmer",
+                "totalVotes": "Sch\u00E4tzungen",
                 "average": "Durchschnitt",
                 "highest": "H\u00F6chster",
-                "showVoters": "Zeige Abstimmer",
+                "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Benutzer"
             }
         }

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -1,6 +1,6 @@
 {
     "appName": "Thunderdome",
-    "appVersion": "Ausführung {version}",
+    "appVersion": "Version {version}",
     "avatarAltText": "Avatar Platzhalter",
     "actions": {
         "logout": {
@@ -25,11 +25,11 @@
             "add": "Plan hinzuf\u00FCgen",
             "view": "Anzeigen",
             "edit": "Bearbeiten",
-            "delete": "l\u00F6schen",
+            "delete": "L\u00F6schen",
             "activate": "Aktivieren",
             "skip": "Plan \u00FCberspringen",
-            "pointed": "Abgestimmt ({count})",
-            "unpointed": "Offen ({count})",
+            "pointed": "Gesch\u00E4tzt ({count})",
+            "unpointed": "Ungesch\u00E4tzt ({count})",
             "finishVoting": "Abstimmung beenden",
             "restartVoting": "Abstimmung neu starten",
             "save": "Speichern",
@@ -52,8 +52,8 @@
                     "placeholder": "Link zum Plan eingeben"
                 },
                 "referenceId": {
-                    "label": "Referenz-ID",
-                    "placeholder": "Referenz-ID eingeben"
+                    "label": "Referenz ID",
+                    "placeholder": "Referenz ID eingeben"
                 },
                 "description": {
                     "label": "Beschreibung",
@@ -76,19 +76,19 @@
     },
     "pages": {
         "landing": {
-            "title": "Thunderdome ist eine Open Source Agile Planning Poker App mit einer lustigen Thematik",
+            "title": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
             "bullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
-            "bullet2": "Einfache {crossoutOpen}Benutzer{crossoutClose}Benutzer Erfahrung",
+            "bullet2": "Einfache Benutzer-Erfahrung",
             "bullet3": "Funktioniert mit allen {mbOpen}modernen Browsers*{mbClose}, inklusive Mobile",
-            "bullet3NotSorry": "*sorry, nicht sorry IE",
+            "bullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
             "features": {
-                "title": "Features",
+                "title": "Eigenschaften",
                 "bullet1": "Keine Beschr\u00E4nkung der Benutzeranzahl einer Sitzung",
                 "bullet2": "Sichere Abstimmung verhindert, dass ein Benutzer schummelt",
                 "bullet3": "Abstimmungsergebnisse, die klar und hilfreich sind",
                 "bullet4": "M\u00F6glichkeit, jeden Benutzer zum Boss zu bef\u00F6rdern",
                 "bullet5": "Anpassbare Punkte-Skalierung",
-                "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Features vorschlagen{contribClose}",
+                "bullet6": "Open Source, gerne {contribOpen}teilnehmen und neue Funktionen vorschlagen{contribClose}",
                 "bullet7": "Keine Geb\u00FChren und ohne Werbung"
             }
         },
@@ -110,16 +110,16 @@
                     },
                     "plans": {
                         "label": "Pl\u00E4ne",
-                        "addButton": "Plan hinzuf\u00FCgen",
+                        "addButton": "Hinzuf\u00FCgen",
                         "removeButton": "Entfernen",
                         "fields": {
                             "name": {
-                                "placeholder": "Plan Namen eingeben"
+                                "placeholder": "Name f\u00FCr den Plan eingeben"
                             }
                         }
                     },
                     "autoFinishVoting": {
-                        "label": "Abstimmung automatisch beenden, wenn alle Benutzer abgegeben haben"
+                        "label": "Abstimmung automatisch beenden, wenn alle Benutzer gesch\u00E4tzt haben"
                     }
                 }
             }
@@ -167,7 +167,7 @@
             "loading": "Konto\u00FCberpr\u00FCfung...",
             "verified": {
                 "title": "Konto \u00FCberpr\u00FCft",
-                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail."
+                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail-Adresse."
             },
             "failed": {
                 "title": "\u00DCberpr\u00FCfung fehlgeschlagen",
@@ -195,7 +195,7 @@
                     "label": "Avatar"
                 },
                 "enable_notifications": {
-                    "label": "Enable session notifications"
+                    "label": "Benachrichtigungen aktivieren"
                 }
             },
             "updatePasswordForm": {
@@ -270,17 +270,17 @@
             "socketReconnecting": "Ooops, Sitzungen werden neu geladen...",
             "socketError": "Fehler beim Eintritt in die Sitzung, bitte aktualisieren und nochmals versuchen.",
             "loading": "Lade Sitzungen...",
-            "votingNotStarted": "Votum noch nicht gestartet",
+            "votingNotStarted": "Sch\u00E4tzung noch nicht gestartet",
             "warriorJoined": "{name} hat die Sitzung betreten",
             "warriorRetreated": "{name} hat die Sitzung verlassen",
-            "warriorVoted": "{name} hat ein Votum abegeben",
-            "warriorRetractedVote": "{name} hat das Votum zur\u00FCckgezogen",
-            "warriorNudge": "pst... {name}, wir warten auf ein Votum.",
+            "warriorVoted": "{name} hat eine Sch\u00E4tzung abegeben",
+            "warriorRetractedVote": "{name} hat die Sch\u00E4tzung zur\u00FCckgezogen",
+            "warriorNudge": "pst... {name}, wir warten auf eine Sch\u00E4tzung",
             "warriorInvite": "Benutzer einladen",
             "warriorLeader": "Chef",
             "finalPoints": "Finale Punkte",
             "points": "Punkte",
-            "planSkipped": "Plan übersprungen",
+            "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
                 "totalVotes": "Abstimmer",
                 "average": "Durchschnitt",

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ type server struct {
 }
 
 func main() {
-	fmt.Printf("Thunderdome version %s", version)
+	log.Println("Thunderdome version " + version)
 
 	InitConfig()
 


### PR DESCRIPTION
Found some typos in the German language file and changed some phrases in order not to sound like Google Translator ;-)

Changed the log message that prints the version during startup so it matches the other messages (timestamp as prefix)