### PR TITLE
Use the JIRA REST Api to transfer tickets into Thunderdome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+*.iml
 
 # Optional eslint cache
 .eslintcache

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ format:
 	$(GOFMT) -s -w datasrc.go
 	$(GOFMT) -s -w handlers.go
 	$(GOFMT) -s -w client.go
+	$(GOFMT) -s -w jira-rest.go
 	$(GOFMT) -s -w hub.go
 	$(GOFMT) -s -w main.go
 	$(GOFMT) -s -w utils.go

--- a/README.md
+++ b/README.md
@@ -130,17 +130,21 @@ The following configuration options exists:
 | `smtp.secure`              | SMTP_SECURE          | Set to authenticate with the Smtp server.  | true |
 | `smtp.identity`            | SMTP_IDENTITY        | Smtp server authorization identity.  Usually unset. | |
 | `smtp.sender`              | SMTP_SENDER          | From address in emails sent by Thunderdome. | no-reply@thunderdome.dev |
-| `config.allowedPointValues` | CONFIG_POINTS_ALLOWED | List of available point values for creating battles. | 0, 1/2, 2, 3, 5, 8, 13, 20, 40, 100, ? |
-| `config.defaultPointValues` | CONFIG_POINTS_DEFAULT | List of default selected points for new battles. | 1, 2, 3, 5, 8 , 13, ? |
-| `config.show_warrior_rank` | CONFIG_SHOW_RANK     | Set to enable an icon showing the rank of a warrior during battle. | false |
-| `config.avatar_service`    | CONFIG_AVATAR_SERVICE | Avatar service used, possible values see next paragraph | default |
-| `config.toast_timeout`     | CONFIG_TOAST_TIMEOUT | Number of milliseconds before notifications are hidden. | 1000 |
-| `config.allow_guests`     | CONFIG_ALLOW_GUESTS | Whether or not to allow guest (anonymous) users. | true |
-| `config.allow_registration`     | CONFIG_ALLOW_REGISTRATION | Whether or not to allow user registration (outside Admin). | true |
-| `config.allow_jira_import`     | CONFIG_ALLOW_JIRA_IMPORT | Whether or not to allow import plans from JIRA XML. | true |
-| `config.default_locale`   | CONFIG_DEFAULT_LOCALE | The default locale (language) for the UI | en |
-| `config.friendly_ui_verbs`    | CONFIG_FRIENDLY_UI_VERBS | Whether or not to use more friendly UI verbs like Users instead of Warrior, e.g. Corporate friendly | false |
-| `auth.method`              |  AUTH_METHOD   | Choose `normal` or `ldap` as authentication method.  See separate section on LDAP configuration. | normal |
+| `config.allowedPointValues`     | CONFIG_POINTS_ALLOWED         | List of available point values for creating battles. | 0, 1/2, 2, 3, 5, 8, 13, 20, 40, 100, ? |
+| `config.defaultPointValues`     | CONFIG_POINTS_DEFAULT         | List of default selected points for new battles. | 1, 2, 3, 5, 8 , 13, ? |
+| `config.show_warrior_rank`      | CONFIG_SHOW_RANK              | Set to enable an icon showing the rank of a warrior during battle. | false |
+| `config.avatar_service`         | CONFIG_AVATAR_SERVICE         | Avatar service used, possible values see next paragraph | default |
+| `config.toast_timeout`          | CONFIG_TOAST_TIMEOUT          | Number of milliseconds before notifications are hidden. | 1000 |
+| `config.allow_guests`           | CONFIG_ALLOW_GUESTS           | Whether or not to allow guest (anonymous) users. | true |
+| `config.allow_registration`     | CONFIG_ALLOW_REGISTRATION     | Whether or not to allow user registration (outside Admin). | true |
+| `config.allow_jira_import_xml`  | CONFIG_ALLOW_JIRA_IMPORT_XML  | Whether or not to allow import plans from JIRA XML. | true |
+| `config.allow_jira_import_rest` | CONFIG_ALLOW_JIRA_IMPORT_REST | Whether or not to allow import plans from JIRA REST API. | false |
+| `config.default_locale`         | CONFIG_DEFAULT_LOCALE         | The default locale (language) for the UI | en |
+| `config.friendly_ui_verbs`      | CONFIG_FRIENDLY_UI_VERBS      | Whether or not to use more friendly UI verbs like Users instead of Warrior, e.g. Corporate friendly | false |
+| `auth.method`                   | AUTH_METHOD                   | Choose `normal` or `ldap` as authentication method.  See separate section on LDAP configuration. | normal |
+| `jira.serverUrl`                | JIRA_SERVER_URL               | Jira server URL where the plans can be loaded from. The application assumes the REST api at path `${jira.serverUrl}/rest/api/2` | https://\[\[server]]/jira |
+| `jira.limit`                    | JIRA_LIMIT                    | Number of tickets imported in one step, must be between 1 - 50 | 30 |
+| `jira.acceptance_fieldname`     | JIRA_ACCEPTANCE_FIELDNAME     | Custom fieldname for acceptance criteria. If set this Jira custom field is used for acceptance criteria. Check your Jira server installation for the correct fieldname (should be something like `customfield_12345`) | |
 
 ## Avatar Service configuration
 

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ The following configuration options exists:
 | `config.toast_timeout`          | CONFIG_TOAST_TIMEOUT          | Number of milliseconds before notifications are hidden. | 1000 |
 | `config.allow_guests`           | CONFIG_ALLOW_GUESTS           | Whether or not to allow guest (anonymous) users. | true |
 | `config.allow_registration`     | CONFIG_ALLOW_REGISTRATION     | Whether or not to allow user registration (outside Admin). | true |
-| `config.allow_jira_import_xml`  | CONFIG_ALLOW_JIRA_IMPORT_XML  | Whether or not to allow import plans from JIRA XML. | true |
-| `config.allow_jira_import_rest` | CONFIG_ALLOW_JIRA_IMPORT_REST | Whether or not to allow import plans from JIRA REST API. | false |
+| `config.allow_jira_import`      | CONFIG_ALLOW_JIRA_IMPORT      | Whether or not to allow import plans from JIRA XML. | true |
 | `config.default_locale`         | CONFIG_DEFAULT_LOCALE         | The default locale (language) for the UI | en |
 | `config.friendly_ui_verbs`      | CONFIG_FRIENDLY_UI_VERBS      | Whether or not to use more friendly UI verbs like Users instead of Warrior, e.g. Corporate friendly | false |
-| `auth.method`                   | AUTH_METHOD                   | Choose `normal` or `ldap` as authentication method.  See separate section on LDAP configuration. | normal |
-| `jira.serverUrl`                | JIRA_SERVER_URL               | Jira server URL where the plans can be loaded from. The application assumes the REST api at path `${jira.serverUrl}/rest/api/2` | https://\[\[server]]/jira |
+| `auth.method`                   | AUTH_METHOD                   | Choose `normal` or `ldap` as authentication method.  See separate section on LDAP configuration. | normal
+| `jira.allow_import_rest`        | JIRA_ALLOW_IMPORT_REST        | Whether or not to allow import plans via JIRA REST interface. | false | 
+| `jira.serverUrl`                | JIRA_SERVER_URL               | Jira server URL where the plans can be loaded from. The application assumes the REST api at path `${jira.serverUrl}/rest/api/2` | |
 | `jira.limit`                    | JIRA_LIMIT                    | Number of tickets imported in one step, must be between 1 - 50 | 30 |
 | `jira.acceptance_fieldname`     | JIRA_ACCEPTANCE_FIELDNAME     | Custom fieldname for acceptance criteria. If set this Jira custom field is used for acceptance criteria. Check your Jira server installation for the correct fieldname (should be something like `customfield_12345`) | |
 

--- a/config.go
+++ b/config.go
@@ -47,7 +47,8 @@ func InitConfig() {
 	viper.SetDefault("config.toast_timeout", 1000)
 	viper.SetDefault("config.allow_guests", true)
 	viper.SetDefault("config.allow_registration", true)
-	viper.SetDefault("config.allow_jira_import", true)
+	viper.SetDefault("config.allow_jira_import_xml", true)
+	viper.SetDefault("config.allow_jira_import_rest", false)
 	viper.SetDefault("config.default_locale", "en")
 	viper.SetDefault("config.friendly_ui_verbs", false)
 
@@ -60,6 +61,10 @@ func InitConfig() {
 	viper.SetDefault("auth.ldap.filter", "(&(objectClass=posixAccount)(mail=%s))")
 	viper.SetDefault("auth.ldap.mail_attr", "mail")
 	viper.SetDefault("auth.ldap.cn_attr", "cn")
+
+	viper.SetDefault("jira.server_url", "https://[[server]]/jira")
+	viper.SetDefault("jira.limit", 30)
+	viper.SetDefault("jira.acceptance_fieldname", "")
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")
@@ -95,7 +100,8 @@ func InitConfig() {
 	viper.BindEnv("config.toast_timeout", "CONFIG_TOAST_TIMEOUT")
 	viper.BindEnv("config.allow_guests", "CONFIG_ALLOW_GUESTS")
 	viper.BindEnv("config.allow_registration", "CONFIG_ALLOW_REGISTRATION")
-	viper.BindEnv("config.allow_jira_import", "CONFIG_ALLOW_JIRA_IMPORT")
+	viper.BindEnv("config.allow_jira_import_xml", "CONFIG_ALLOW_JIRA_IMPORT_XML")
+	viper.BindEnv("config.allow_jira_import_rest", "CONFIG_ALLOW_JIRA_IMPORT_REST")
 	viper.BindEnv("config.default_locale", "CONFIG_DEFAULT_LOCALE")
 	viper.BindEnv("config.friendly_ui_verbs", "CONFIG_FRIENDLY_UI_VERBS")
 
@@ -108,6 +114,10 @@ func InitConfig() {
 	viper.BindEnv("auth.ldap.filter", "AUTH_LDAP_FILTER")
 	viper.BindEnv("auth.ldap.mail_attr", "AUTH_LDAP_MAIL_ATTR")
 	viper.BindEnv("auth.ldap.cn_attr", "AUTH_LDAP_CN_ATTR")
+
+	viper.BindEnv("jira.server_url", "JIRA_SERVER_URL")
+	viper.BindEnv("jira.limit", "JIRA_LIMIT")
+	viper.BindEnv("jira.acceptance_fieldname", "JIRA_ACCEPTANCE_FIELDNAME")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -47,8 +47,7 @@ func InitConfig() {
 	viper.SetDefault("config.toast_timeout", 1000)
 	viper.SetDefault("config.allow_guests", true)
 	viper.SetDefault("config.allow_registration", true)
-	viper.SetDefault("config.allow_jira_import_xml", true)
-	viper.SetDefault("config.allow_jira_import_rest", false)
+	viper.SetDefault("config.allow_jira_import", true)
 	viper.SetDefault("config.default_locale", "en")
 	viper.SetDefault("config.friendly_ui_verbs", false)
 
@@ -62,7 +61,8 @@ func InitConfig() {
 	viper.SetDefault("auth.ldap.mail_attr", "mail")
 	viper.SetDefault("auth.ldap.cn_attr", "cn")
 
-	viper.SetDefault("jira.server_url", "https://[[server]]/jira")
+	viper.SetDefault("jira.auth_method", "token")
+	viper.SetDefault("jira.allow_import_rest", false)
 	viper.SetDefault("jira.limit", 30)
 	viper.SetDefault("jira.acceptance_fieldname", "")
 
@@ -100,8 +100,7 @@ func InitConfig() {
 	viper.BindEnv("config.toast_timeout", "CONFIG_TOAST_TIMEOUT")
 	viper.BindEnv("config.allow_guests", "CONFIG_ALLOW_GUESTS")
 	viper.BindEnv("config.allow_registration", "CONFIG_ALLOW_REGISTRATION")
-	viper.BindEnv("config.allow_jira_import_xml", "CONFIG_ALLOW_JIRA_IMPORT_XML")
-	viper.BindEnv("config.allow_jira_import_rest", "CONFIG_ALLOW_JIRA_IMPORT_REST")
+	viper.BindEnv("config.allow_jira_import", "CONFIG_ALLOW_JIRA_IMPORT")
 	viper.BindEnv("config.default_locale", "CONFIG_DEFAULT_LOCALE")
 	viper.BindEnv("config.friendly_ui_verbs", "CONFIG_FRIENDLY_UI_VERBS")
 
@@ -115,6 +114,8 @@ func InitConfig() {
 	viper.BindEnv("auth.ldap.mail_attr", "AUTH_LDAP_MAIL_ATTR")
 	viper.BindEnv("auth.ldap.cn_attr", "AUTH_LDAP_CN_ATTR")
 
+	viper.BindEnv("jira.allow_import_rest", "JIRA_ALLOW_IMPORT_REST")
+	viper.BindEnv("jira.auth_method", "JIRA_AUTH_METHOD")
 	viper.BindEnv("jira.server_url", "JIRA_SERVER_URL")
 	viper.BindEnv("jira.limit", "JIRA_LIMIT")
 	viper.BindEnv("jira.acceptance_fieldname", "JIRA_ACCEPTANCE_FIELDNAME")

--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -38,6 +38,10 @@
                 "badFileType": "Fehler: falscher Datei-Typ",
                 "errorReadingFile": "Fehler beim Lesen der Datei"
             },
+            "importJiraRest": {
+                "button": "Jira REST Import",
+                "process": "Import"
+            },
             "fields": {
                 "name": {
                     "label": "Plan Name",
@@ -287,6 +291,29 @@
                 "highest": "H\u00F6chster",
                 "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Krieger"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Benutzername",
+                    "placeholder": "Benutzername eingeben"
+                },
+                "password": {
+                    "label": "Passwort",
+                    "placeholder": "Passwort eingeben"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "JIRA Server URL eingeben"
+                },
+                "jql": {
+                    "label": "Erweiterte Suche (JQL)",
+                    "placeholder": "JQL eingeben"
+                }
+            },
+            "sendRequest": {
+                "error": "Es ist nicht m\u00F6glich, Tickets per REST zu beziehen"
             }
         }
     },

--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Benachrichtigungen aktivieren"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (passend zur E-Mail)",
+                    "placeholder": "Bitte das API Token eingeben"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Passwort",
                     "placeholder": "Passwort eingeben"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "JIRA Server URL eingeben"
                 },
@@ -314,6 +318,9 @@
             },
             "sendRequest": {
                 "error": "Es ist nicht m\u00F6glich, Tickets per REST zu beziehen"
+            },
+            "apiToken": {
+                "error": "Der Rest Service ist f\u00FCr Jira API Token konfiguriert. Bitte im Benutzer-Profil ein entsprechendes Token konfigurieren."
             }
         }
     },

--- a/frontend/public/lang/default/en.json
+++ b/frontend/public/lang/default/en.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Enable battle notifications"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (associated with email)",
+                    "placeholder": "Enter REST API token"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Password",
                     "placeholder": "Please enter password"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "Please enter JIRA Server URL"
                 },
@@ -314,6 +318,9 @@
             },
             "sendRequest": {
                 "error": "Unable to retrieve the tickets from Jira via REST"
+            },
+            "apiToken": {
+                "error": "The REST service has been configured to use Jira API Token. Please add one to your profile."
             }
         }
     },

--- a/frontend/public/lang/default/en.json
+++ b/frontend/public/lang/default/en.json
@@ -34,9 +34,13 @@
             "restartVoting": "Restart Voting",
             "save": "Save",
             "importJiraXML": {
-                "button": "Import plans from Jira XML",
+                "button": "Import Jira XML",
                 "badFileType": "Error bad file type",
                 "errorReadingFile": "Error reading file"
+            },
+            "importJiraRest": {
+                "button": "Import Jira REST",
+                "process": "Import"
             },
             "fields": {
                 "name": {
@@ -287,6 +291,29 @@
                 "highest": "Highest",
                 "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Warrior"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Username",
+                    "placeholder": "Please enter username"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Please enter password"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "Please enter JIRA Server URL"
+                },
+                "jql": {
+                    "label": "JQL Ticket search string",
+                    "placeholder": "Please enter JQL search string"
+                }
+            },
+            "sendRequest": {
+                "error": "Unable to retrieve the tickets from Jira via REST"
             }
         }
     },

--- a/frontend/public/lang/default/ru.json
+++ b/frontend/public/lang/default/ru.json
@@ -38,6 +38,10 @@
                 "badFileType": "Ошибка: плохой тип файла",
                 "errorReadingFile": "Ошибка чтения файла"
             },
+            "importJiraRest": {
+                "button": "Import Jira REST",
+                "process": "Import"
+            },
             "fields": {
                 "name": {
                     "label": "Заголовок задачи",
@@ -287,6 +291,29 @@
                 "highest": "Лучшее",
                 "showVoters": "Показать проголосовавших",
                 "unknownWarrior": "Неизвестный участник"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Username",
+                    "placeholder": "Please enter username"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Please enter password"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "Please enter JIRA Server URL"
+                },
+                "jql": {
+                    "label": "JQL Ticket search string",
+                    "placeholder": "Please enter JQL search string"
+                }
+            },
+            "sendRequest": {
+                "error": "Unable to retrieve the tickets from Jira via REST"
             }
         }
     },

--- a/frontend/public/lang/default/ru.json
+++ b/frontend/public/lang/default/ru.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Включить уведомления"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (associated with email)",
+                    "placeholder": "Enter REST API token"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Password",
                     "placeholder": "Please enter password"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "Please enter JIRA Server URL"
                 },
@@ -314,6 +318,9 @@
             },
             "sendRequest": {
                 "error": "Unable to retrieve the tickets from Jira via REST"
+            },
+            "apiToken": {
+                "error": "The REST service has been configured to use Jira API Token. Please add one to your profile."
             }
         }
     },

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -38,7 +38,11 @@
                 "badFileType": "Fehler: falscher Datei-Typ",
                 "errorReadingFile": "Fehler beim Lesen der Datei"
             },
-            "fields": {
+            "importJiraRest": {
+                "button": "Jira REST Import",
+                "process": "Import"
+            },
+           "fields": {
                 "name": {
                     "label": "Plan Name",
                     "placeholder": "Plan Name eingeben"
@@ -287,6 +291,29 @@
                 "highest": "H\u00F6chster",
                 "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Benutzer"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Benutzername",
+                    "placeholder": "Benutzername eingeben"
+                },
+                "password": {
+                    "label": "Passwort",
+                    "placeholder": "Passwort eingeben"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "JIRA Server URL eingeben"
+                },
+                "jql": {
+                    "label": "Erweiterte Suche (JQL)",
+                    "placeholder": "JQL eingeben"
+                }
+            },
+            "sendRequest": {
+                "error": "Es ist nicht m\u00F6glich, Tickets per REST zu beziehen"
             }
         }
     },

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Benachrichtigungen aktivieren"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (passend zur E-Mail)",
+                    "placeholder": "Bitte das API Token eingeben"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Passwort",
                     "placeholder": "Passwort eingeben"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "JIRA Server URL eingeben"
                 },
@@ -314,6 +318,9 @@
             },
             "sendRequest": {
                 "error": "Es ist nicht m\u00F6glich, Tickets per REST zu beziehen"
+            },
+            "apiToken": {
+                "error": "Der Rest Service ist f\u00FCr Jira API Token konfiguriert. Bitte im Benutzer-Profil ein entsprechendes Token konfigurieren."
             }
         }
     },

--- a/frontend/public/lang/friendly/en.json
+++ b/frontend/public/lang/friendly/en.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Enable game notifications"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (associated with email)",
+                    "placeholder": "Enter REST API token"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Password",
                     "placeholder": "Please enter password"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "Please enter JIRA Server URL"
                 },

--- a/frontend/public/lang/friendly/en.json
+++ b/frontend/public/lang/friendly/en.json
@@ -38,6 +38,10 @@
                 "badFileType": "Error bad file type",
                 "errorReadingFile": "Error reading file"
             },
+            "importJiraRest": {
+                "button": "Import Jira REST",
+                "process": "Import"
+            },
             "fields": {
                 "name": {
                     "label": "Story Name",
@@ -287,6 +291,29 @@
                 "highest": "Highest",
                 "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Player"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Username",
+                    "placeholder": "Please enter username"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Please enter password"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "Please enter JIRA Server URL"
+                },
+                "jql": {
+                    "label": "JQL Ticket search string",
+                    "placeholder": "Please enter JQL search string"
+                }
+            },
+            "sendRequest": {
+                "error": "Unable to retrieve the tickets from Jira via REST"
             }
         }
     },

--- a/frontend/public/lang/friendly/ru.json
+++ b/frontend/public/lang/friendly/ru.json
@@ -38,6 +38,10 @@
                 "badFileType": "Ошибка: плохой тип файла",
                 "errorReadingFile": "Ошибка чтения файла"
             },
+            "importJiraRest": {
+                "button": "Import Jira REST",
+                "process": "Import"
+            },
             "fields": {
                 "name": {
                     "label": "Заголовок задачи",
@@ -287,6 +291,29 @@
                 "highest": "Лучшее",
                 "showVoters": "Показать проголосовавших",
                 "unknownWarrior": "Неизвестный участник"
+            }
+        },
+        "jiraRestCfg": {
+            "fields":{
+                "username" : {
+                    "label": "Username",
+                    "placeholder": "Please enter username"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Please enter password"
+                },
+                "apiEndpoint": {
+                    "label": "JIRA Server URL",
+                    "placeholder": "Please enter JIRA Server URL"
+                },
+                "jql": {
+                    "label": "JQL Ticket search string",
+                    "placeholder": "Please enter JQL search string"
+                }
+            },
+            "sendRequest": {
+                "error": "Unable to retrieve the tickets from Jira via REST"
             }
         }
     },

--- a/frontend/public/lang/friendly/ru.json
+++ b/frontend/public/lang/friendly/ru.json
@@ -200,6 +200,10 @@
                 },
                 "enable_notifications": {
                     "label": "Включить уведомления"
+                },
+                "jiraRestApiToken": {
+                    "label": "JIRA Rest API Token (associated with email)",
+                    "placeholder": "Enter REST API token"
                 }
             },
             "updatePasswordForm": {
@@ -303,7 +307,7 @@
                     "label": "Password",
                     "placeholder": "Please enter password"
                 },
-                "apiEndpoint": {
+                "serverUrl": {
                     "label": "JIRA Server URL",
                     "placeholder": "Please enter JIRA Server URL"
                 },
@@ -314,6 +318,9 @@
             },
             "sendRequest": {
                 "error": "Unable to retrieve the tickets from Jira via REST"
+            },
+            "apiToken": {
+                "error": "The REST service has been configured to use Jira API Token. Please add one to your profile."
             }
         }
     },

--- a/frontend/src/components/BattlePlans.svelte
+++ b/frontend/src/components/BattlePlans.svelte
@@ -4,6 +4,7 @@
     import HollowButton from './HollowButton.svelte'
     import ViewPlan from './ViewPlan.svelte'
     import JiraImport from './JiraImport.svelte'
+    import JiraImportRest from './JiraImportRest.svelte'
     import { _ } from '../i18n'
 
     export let plans = []
@@ -11,6 +12,7 @@
     export let sendSocketEvent = () => {}
     export let eventTag
     export let notifications
+    export let xfetch
 
     const defaultPlan = {
         id: '',
@@ -90,7 +92,15 @@
         </div>
         <div class="w-1/2 text-right">
             {#if isLeader}
-                <JiraImport {handlePlanAdd} {notifications} {eventTag} />
+                <JiraImport
+                        {handlePlanAdd}
+                        {notifications}
+                        {eventTag} />
+                <JiraImportRest
+                        {handlePlanAdd}
+                        {notifications}
+                        {eventTag}
+                        {xfetch} />
                 <HollowButton onClick="{toggleAddPlan()}">
                     {$_('actions.plan.add')}
                 </HollowButton>

--- a/frontend/src/components/CreateBattle.svelte
+++ b/frontend/src/components/CreateBattle.svelte
@@ -4,6 +4,7 @@
     import SolidButton from './SolidButton.svelte'
     import HollowButton from './HollowButton.svelte'
     import JiraImport from './JiraImport.svelte'
+    import JiraImportRest from './JiraImportRest.svelte'
     import { warrior } from '../stores.js'
     import { _ } from '../i18n'
     import { appRoutes } from '../config'
@@ -141,6 +142,11 @@
                 handlePlanAdd="{handlePlanImport}"
                 {notifications}
                 {eventTag} />
+            <JiraImportRest
+                handlePlanAdd="{handlePlanImport}"
+                {notifications}
+                {eventTag}
+                {xfetch} />
             <HollowButton onClick="{addPlan}">
                 {$_('pages.myBattles.createBattle.fields.plans.addButton')}
             </HollowButton>

--- a/frontend/src/components/JiraImport.svelte
+++ b/frontend/src/components/JiraImport.svelte
@@ -8,7 +8,7 @@
     export let eventTag = () => {}
     export let handlePlanAdd = () => {}
 
-    const allowJiraImport = appConfig.AllowJiraImport
+    const allowJiraImport = appConfig.AllowJiraImportXml
 
     function uploadFile() {
         let file = this.files[0]

--- a/frontend/src/components/JiraImportRest.svelte
+++ b/frontend/src/components/JiraImportRest.svelte
@@ -57,7 +57,7 @@
         const body = {
             userName: restCfg.userName,
             password: restCfg.password,
-            endpoint: restCfg.apiEndpoint,
+            endpoint: restCfg.serverUrl,
             jql: restCfg.jql,
         }
 

--- a/frontend/src/components/JiraImportRest.svelte
+++ b/frontend/src/components/JiraImportRest.svelte
@@ -1,0 +1,91 @@
+<script>
+    import HollowButton from './HollowButton.svelte'
+    import {_} from '../i18n'
+    import he from 'he'
+    import JiraImportServerData from './JiraImportServerData.svelte'
+
+    let showJiraRestConfig = false
+
+    export let xfetch
+    export let notifications
+    export let eventTag
+    export let handlePlanAdd = () => {}
+
+    const allowJiraImport = appConfig.AllowJiraImportRest
+    const jiraServerUrl = appConfig.JiraServerUrl
+
+    function toggleJiraRestConfig() {
+        showJiraRestConfig = !showJiraRestConfig
+    }
+
+    function processResponse(response) {
+        if (response != null) {
+            for (let i = 0; i < response.issues.length; i++) {
+                const item = response.issues[i]
+                // decode description and acceptance criteria
+                const decodedDescription = he.decode(
+                    item.fields.description,
+                )
+                const acceptanceCriteria = he.decode(
+                    item.fields.acceptanceCriteria,
+                )
+                const ticketLink = jiraServerUrl + "/browse/" + item.key
+                const plan = {
+                    id: '',
+                    planName: item.fields.summary,
+                    type: item.fields.issuetype.name.toLowerCase(),
+                    referenceId: item.key,
+                    link: ticketLink,
+                    description: decodedDescription,
+                    acceptanceCriteria,
+                }
+                handlePlanAdd(plan)
+            }
+            eventTag(
+                'jira_import_success',
+                'battle',
+                `total tickets imported: ${response.Total}`,
+            )
+        }
+    }
+
+    function handleImportFromRest(restCfg) {
+        const body = {
+            userName: restCfg.userName,
+            password: restCfg.password,
+            endpoint: restCfg.apiEndpoint,
+            jql: restCfg.jql,
+        }
+
+        xfetch('/api/jira/tickets', { body })
+            .then(res => res.json())
+            .then(function (response) {
+                processResponse(response)
+            })
+            .catch(function (error){
+                notifications.danger(
+                    $_('pages.jiraRestCfg.sendRequest.error')
+                )
+                eventTag('jira_rest_request', 'battle', 'failure')
+            })
+
+
+        // hide the dialogue
+        toggleJiraRestConfig();
+    }
+</script>
+
+{#if allowJiraImport}
+    <HollowButton
+            color="blue"
+            onClick="{toggleJiraRestConfig}"
+            additionalClasses="mr-2">
+        {$_('actions.plan.importJiraRest.button')}
+    </HollowButton>
+{/if}
+{#if showJiraRestConfig}
+    <JiraImportServerData
+            {handleImportFromRest}
+            {toggleJiraRestConfig}
+    />
+{/if}

--- a/frontend/src/components/JiraImportRest.svelte
+++ b/frontend/src/components/JiraImportRest.svelte
@@ -18,17 +18,21 @@
         showJiraRestConfig = !showJiraRestConfig
     }
 
+    function transformLineBreaks(text) {
+        return text.replace(/\r/g, "").replace(/\n/g, "<br/>")
+    }
+
     function processResponse(response) {
         if (response != null) {
             for (let i = 0; i < response.issues.length; i++) {
                 const item = response.issues[i]
                 // decode description and acceptance criteria
-                const decodedDescription = he.decode(
+                const decodedDescription = transformLineBreaks(he.decode(
                     item.fields.description,
-                )
-                const acceptanceCriteria = he.decode(
+                ))
+                const acceptanceCriteria = transformLineBreaks(he.decode(
                     item.fields.acceptanceCriteria,
-                )
+                ))
                 const ticketLink = jiraServerUrl + "/browse/" + item.key
                 const plan = {
                     id: '',

--- a/frontend/src/components/JiraImportServerData.svelte
+++ b/frontend/src/components/JiraImportServerData.svelte
@@ -1,0 +1,136 @@
+<script>
+    import SolidButton from './SolidButton.svelte'
+    import CloseIcon from './icons/CloseIcon.svelte'
+    import {_} from '../i18n'
+
+    const apiEndPointConfigured = appConfig.JiraServerUrl
+
+    export let toggleJiraRestConfig = () => {}
+    export let handleImportFromRest = () => {}
+
+    export let userName = ''
+    export let password = ''
+    export let apiEndpoint = apiEndPointConfigured
+    export let jql = ''
+
+    function takeOverConfig(e) {
+        e.preventDefault()
+
+        const restCfg = {
+            userName,
+            password,
+            apiEndpoint,
+            jql
+        }
+
+        handleImportFromRest(restCfg)
+    }
+
+
+</script>
+<div
+        class="fixed inset-0 flex items-center z-40 max-h-screen overflow-y-scroll">
+    <div class="fixed inset-0 bg-gray-900 opacity-75"></div>
+
+    <div
+            class="relative mx-4 md:mx-auto w-full md:w-2/3 lg:w-3/5 xl:w-1/2 z-50
+        max-h-full">
+        <div class="py-8">
+            <div class="shadow-xl bg-white rounded-lg p-4 xl:p-6 max-h-full">
+                <div class="flex justify-end mb-2">
+                    <button
+                            aria-label="close"
+                            on:click="{toggleJiraRestConfig}"
+                            class="text-gray-800">
+                        <CloseIcon/>
+                    </button>
+                </div>
+                <form on:submit="{takeOverConfig}" name="JiraRestConfig">
+                    <div class="mb-4">
+                        <label
+                                class="block text-gray-700 text-sm font-bold mb-2"
+                                for="userName">
+                            {$_('pages.jiraRestCfg.fields.username.label')}
+                        </label>
+                        <div class="control">
+                            <input
+                                    name="userName"
+                                    bind:value="{userName}"
+                                    placeholder="{$_('pages.jiraRestCfg.fields.username.placeholder')}"
+                                    class="bg-gray-200 border-gray-200 border-2
+                                appearance-none rounded w-full py-2 px-3
+                                text-gray-700 leading-tight focus:outline-none
+                                focus:bg-white focus:border-purple-500"
+                                    id="userName"
+                                    required/>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label
+                                class="block text-gray-700 text-sm font-bold mb-2"
+                                for="password">
+                            {$_('pages.jiraRestCfg.fields.password.label')}
+                        </label>
+                        <div class="control">
+                            <input
+                                    bind:value="{password}"
+                                    placeholder="{$_('pages.jiraRestCfg.fields.password.placeholder')}"
+                                    class="bg-gray-200 border-gray-200 border-2 appearance-none rounded
+                                w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none
+                                focus:bg-white focus:border-purple-500"
+                                    id="password"
+                                    name="password"
+                                    type="password"
+                                    required/>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label
+                                class="block text-gray-700 text-sm font-bold mb-2"
+                                for="apiEndpoint">
+                            {$_('pages.jiraRestCfg.fields.apiEndpoint.label')}
+                        </label>
+                        <div class="control">
+                            <input
+                                    name="apiEndpoint"
+                                    bind:value="{apiEndpoint}"
+                                    placeholder="{$_('pages.jiraRestCfg.fields.apiEndpoint.placeholder')}"
+                                    class="bg-gray-200 border-gray-200 border-2
+                                appearance-none rounded w-full py-2 px-3
+                                text-gray-700 leading-tight focus:outline-none
+                                focus:bg-white focus:border-purple-500"
+                                    id="apiEndpoint"
+                                    required/>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <label
+                                class="block text-gray-700 text-sm font-bold mb-2"
+                                for="jql">
+                            {$_('pages.jiraRestCfg.fields.jql.label')}
+                        </label>
+                        <div class="control">
+                            <input
+                                    name="jql"
+                                    bind:value="{jql}"
+                                    placeholder="{$_('pages.jiraRestCfg.fields.jql.placeholder')}"
+                                    class="bg-gray-200 border-gray-200 border-2
+                                appearance-none rounded w-full py-2 px-3
+                                text-gray-700 leading-tight focus:outline-none
+                                focus:bg-white focus:border-purple-500"
+                                    id="jql"
+                                    type="text"
+                                    required/>
+                        </div>
+                    </div>
+
+                    <div class="text-right">
+                        <SolidButton type="submit">
+                            {$_('actions.plan.importJiraRest.button')}
+                        </SolidButton>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/src/pages/Battle.svelte
+++ b/frontend/src/pages/Battle.svelte
@@ -17,6 +17,7 @@
     import { appRoutes, PathPrefix } from '../config'
 
     export let battleId
+    export let xfetch
     export let notifications
     export let eventTag
     export let router
@@ -490,7 +491,8 @@
                     isLeader="{battle.leaderId === $warrior.id}"
                     {sendSocketEvent}
                     {eventTag}
-                    {notifications} />
+                    {notifications}
+                    {xfetch} />
             </div>
 
             <div class="w-full lg:w-1/4 px-4">

--- a/frontend/src/pages/WarriorProfile.svelte
+++ b/frontend/src/pages/WarriorProfile.svelte
@@ -20,7 +20,10 @@
     let updatePassword = false
     let warriorPassword1 = ''
     let warriorPassword2 = ''
+    let jiraRestApiToken = ''
 
+    const allowJiraImport = appConfig.AllowJiraImportRest
+    const jiraAuthMethod = appConfig.JiraAuthMethod.toLowerCase()
     const avatarService = appConfig.AvatarService
     let avatars
 
@@ -75,6 +78,7 @@
         const body = {
             warriorName: warriorProfile.name,
             warriorAvatar: warriorProfile.avatar,
+            jiraRestApiToken: warriorProfile.jiraRestApiToken,
             notificationsEnabled: warriorProfile.notificationsEnabled,
         }
         const validName = validateName(body.warriorName)
@@ -96,6 +100,7 @@
                         email: warriorProfile.email,
                         rank: warriorProfile.rank,
                         avatar: warriorProfile.avatar,
+                        jiraRestApiToken: warriorProfile.jiraRestApiToken,
                         notificationsEnabled:
                             warriorProfile.notificationsEnabled,
                     })
@@ -233,7 +238,26 @@
                             </span>
                         </label>
                     </div>
-
+                    {#if allowJiraImport && jiraAuthMethod == 'token'}
+                        <div class="mb-4">
+                            <label
+                                class="block text-gray-700 text-sm font-bold mb-2"
+                                for="jiraRestApiToken">
+                                {$_('pages.warriorProfile.fields.jiraRestApiToken.label')}
+                            </label>
+                            <input 
+                                bind:value="{warriorProfile.jiraRestApiToken}"
+                                placeholder="{$_('pages.warriorProfile.fields.jiraRestApiToken.placeholder')}"
+                                class="bg-gray-200 border-gray-200 border-2
+                                appearance-none rounded w-full py-2 px-3
+                                text-gray-700 leading-tight focus:outline-none
+                                focus:bg-white focus:border-purple-500"
+                                id="jiraRestApiToken"
+                                name="jiraRestApiToken"/>
+                        </div>
+                    {/if}
+                
+                
                     {#if avatarService == 'dicebear' || avatarService == 'gravatar' || avatarService == 'robohash' || avatarService == 'govatar'}
                         <div class="mb-4">
                             <label

--- a/handlers.go
+++ b/handlers.go
@@ -181,6 +181,7 @@ func (s *server) handleIndex() http.HandlerFunc {
 		FriendlyUIVerbs     bool
 		AuthMethod          string
 		JiraServerUrl       string
+		JiraAuthMethod      string
 		AppVersion          string
 		CookieName          string
 		PathPrefix          string
@@ -219,12 +220,13 @@ func (s *server) handleIndex() http.HandlerFunc {
 		ToastTimeout:        viper.GetInt("config.toast_timeout"),
 		AllowGuests:         viper.GetBool("config.allow_guests"),
 		AllowRegistration:   viper.GetBool("config.allow_registration") && viper.GetString("auth.method") == "normal",
-		AllowJiraImportXml:  viper.GetBool("config.allow_jira_import_xml"),
-		AllowJiraImportRest: viper.GetBool("config.allow_jira_import_rest"),
+		AllowJiraImportXml:  viper.GetBool("config.allow_jira_import"),
+		AllowJiraImportRest: viper.GetBool("jira.allow_import_rest"),
 		DefaultLocale:       viper.GetString("config.default_locale"),
 		FriendlyUIVerbs:     viper.GetBool("config.friendly_ui_verbs"),
 		AuthMethod:          viper.GetString("auth.method"),
 		JiraServerUrl:       viper.GetString("jira.server_url"),
+		JiraAuthMethod:      viper.GetString("jira.auth_method"),
 		AppVersion:          s.config.Version,
 		CookieName:          s.config.FrontendCookieName,
 		PathPrefix:          s.config.PathPrefix,
@@ -578,6 +580,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 		json.Unmarshal(body, &keyVal) // check for errors
 		WarriorName := keyVal["warriorName"].(string)
 		WarriorAvatar := keyVal["warriorAvatar"].(string)
+		JiraRestApiToken := keyVal["jiraRestApiToken"].(string)
 		NotificationsEnabled, _ := keyVal["notificationsEnabled"].(bool)
 
 		WarriorID := vars["id"]
@@ -587,7 +590,7 @@ func (s *server) handleWarriorProfileUpdate() http.HandlerFunc {
 			return
 		}
 
-		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName, WarriorAvatar, NotificationsEnabled)
+		updateErr := s.database.UpdateWarriorProfile(WarriorID, WarriorName, WarriorAvatar, NotificationsEnabled, JiraRestApiToken)
 		if updateErr != nil {
 			log.Println("error attempting to update warrior profile : " + updateErr.Error() + "\n")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/handlers.go
+++ b/handlers.go
@@ -168,20 +168,22 @@ func (s *server) adminOnly(h http.HandlerFunc) http.HandlerFunc {
 // handleIndex parses the index html file, injecting any relevant data
 func (s *server) handleIndex() http.HandlerFunc {
 	type AppConfig struct {
-		AllowedPointValues []string
-		DefaultPointValues []string
-		ShowWarriorRank    bool
-		AvatarService      string
-		ToastTimeout       int
-		AllowGuests        bool
-		AllowRegistration  bool
-		AllowJiraImport    bool
-		DefaultLocale      string
-		FriendlyUIVerbs    bool
-		AuthMethod         string
-		AppVersion         string
-		CookieName         string
-		PathPrefix         string
+		AllowedPointValues  []string
+		DefaultPointValues  []string
+		ShowWarriorRank     bool
+		AvatarService       string
+		ToastTimeout        int
+		AllowGuests         bool
+		AllowRegistration   bool
+		AllowJiraImportXml  bool
+		AllowJiraImportRest bool
+		DefaultLocale       string
+		FriendlyUIVerbs     bool
+		AuthMethod          string
+		JiraServerUrl       string
+		AppVersion          string
+		CookieName          string
+		PathPrefix          string
 	}
 	type UIConfig struct {
 		AnalyticsEnabled bool
@@ -210,20 +212,22 @@ func (s *server) handleIndex() http.HandlerFunc {
 	}
 
 	appConfig := AppConfig{
-		AllowedPointValues: viper.GetStringSlice("config.allowedPointValues"),
-		DefaultPointValues: viper.GetStringSlice("config.defaultPointValues"),
-		ShowWarriorRank:    viper.GetBool("config.show_warrior_rank"),
-		AvatarService:      viper.GetString("config.avatar_service"),
-		ToastTimeout:       viper.GetInt("config.toast_timeout"),
-		AllowGuests:        viper.GetBool("config.allow_guests"),
-		AllowRegistration:  viper.GetBool("config.allow_registration") && viper.GetString("auth.method") == "normal",
-		AllowJiraImport:    viper.GetBool("config.allow_jira_import"),
-		DefaultLocale:      viper.GetString("config.default_locale"),
-		FriendlyUIVerbs:    viper.GetBool("config.friendly_ui_verbs"),
-		AuthMethod:         viper.GetString("auth.method"),
-		AppVersion:         s.config.Version,
-		CookieName:         s.config.FrontendCookieName,
-		PathPrefix:         s.config.PathPrefix,
+		AllowedPointValues:  viper.GetStringSlice("config.allowedPointValues"),
+		DefaultPointValues:  viper.GetStringSlice("config.defaultPointValues"),
+		ShowWarriorRank:     viper.GetBool("config.show_warrior_rank"),
+		AvatarService:       viper.GetString("config.avatar_service"),
+		ToastTimeout:        viper.GetInt("config.toast_timeout"),
+		AllowGuests:         viper.GetBool("config.allow_guests"),
+		AllowRegistration:   viper.GetBool("config.allow_registration") && viper.GetString("auth.method") == "normal",
+		AllowJiraImportXml:  viper.GetBool("config.allow_jira_import_xml"),
+		AllowJiraImportRest: viper.GetBool("config.allow_jira_import_rest"),
+		DefaultLocale:       viper.GetString("config.default_locale"),
+		FriendlyUIVerbs:     viper.GetBool("config.friendly_ui_verbs"),
+		AuthMethod:          viper.GetString("auth.method"),
+		JiraServerUrl:       viper.GetString("jira.server_url"),
+		AppVersion:          s.config.Version,
+		CookieName:          s.config.FrontendCookieName,
+		PathPrefix:          s.config.PathPrefix,
 	}
 
 	data := UIConfig{
@@ -726,5 +730,49 @@ func (s *server) handleWarriorAvatar() http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+	}
+}
+
+/*
+	JIRA Rest handlers
+*/
+
+func (s *server) handleGetJiraTickets() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		warriorID, cookieErr := s.validateWarriorCookie(w, r)
+		if cookieErr != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		_, warErr := s.database.GetWarrior(warriorID)
+
+		if warErr != nil {
+			log.Println("error finding warrior : " + warErr.Error() + "\n")
+			s.clearWarriorCookies(w)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		body, bodyErr := ioutil.ReadAll(r.Body) // check for errors
+		if bodyErr != nil {
+			log.Println("error reading JIRA REST config : " + bodyErr.Error() + "\n")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var keyVal struct {
+			UserName string `json:"userName"`
+			Password string `json:"password"`
+			EndPoint string `json:"endpoint"`
+			Jql      string `json:"jql"`
+		}
+		json.Unmarshal(body, &keyVal) // check for errors
+
+		api := keyVal.EndPoint + "/rest/api/2/search?jql="
+
+		response := getListOfTickets(keyVal.UserName, keyVal.Password, api, keyVal.Jql)
+
+		RespondWithJSON(w, http.StatusOK, response)
 	}
 }

--- a/jira-rest.go
+++ b/jira-rest.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+type Jira struct {
+	Total  int     `json:"total"`
+	Issues []Issue `json:"issues"`
+}
+
+type Issue struct {
+	Key    string `json:"key"`
+	Fields Fields `json:"fields"`
+}
+
+type Fields struct {
+	Summary            string    `json:"summary"`
+	AcceptanceCriteria string    `json:"acceptanceCriteria"`
+	IssueType          IssueType `json:"issuetype"`
+	Description        string    `json:"description"`
+}
+
+type IssueType struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func encodeJql(jql string) string {
+	return url.QueryEscape(jql)
+}
+
+func createQueryParams() string {
+	nameFieldAcceptanceCriteria := viper.GetString("jira.acceptance_fieldname")
+	if nameFieldAcceptanceCriteria != "" {
+		nameFieldAcceptanceCriteria = "," + nameFieldAcceptanceCriteria
+	}
+	// limit fields to the few required to create a plan
+	fields := "&fields=summary,issuetype,description" + nameFieldAcceptanceCriteria
+
+	limit := viper.GetInt("jira.limit")
+	if limit > 50 {
+		limit = 50
+	}
+
+	// limit the result to a maximum
+	maxResults := "&maxResults=" + strconv.Itoa(limit)
+	// send back combination all query parameters
+	return fields + maxResults
+}
+
+func simplifyResponse(bodyBytes []byte) []byte {
+	nameFieldAcceptanceCriteria := viper.GetString("jira.acceptance_fieldname")
+	if nameFieldAcceptanceCriteria != "" {
+		bodyString := string(bodyBytes)
+		return []byte(strings.ReplaceAll(bodyString, nameFieldAcceptanceCriteria, "acceptanceCriteria"))
+	} else {
+		return bodyBytes
+	}
+}
+
+func getListOfTickets(username string, passwd string, url string, jql string) Jira {
+	var target = url + encodeJql(jql) + createQueryParams()
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", target, nil)
+	req.SetBasicAuth(username, passwd)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+
+	simpleResponse := simplifyResponse(bodyBytes)
+
+	var jiraRoot Jira
+	json.Unmarshal(simpleResponse, &jiraRoot)
+
+	return jiraRoot
+}

--- a/pkg/database/types.go
+++ b/pkg/database/types.go
@@ -51,6 +51,7 @@ type Warrior struct {
 	WarriorEmail         string `json:"email"`
 	WarriorRank          string `json:"rank"`
 	WarriorAvatar        string `json:"avatar"`
+	JiraRestApiToken     string `json:"jiraRestApiToken"`
 	Verified             bool   `json:"verified"`
 	NotificationsEnabled bool   `json:"notificationsEnabled"`
 }

--- a/pkg/database/warriors.go
+++ b/pkg/database/warriors.go
@@ -41,7 +41,7 @@ func (d *Database) GetWarrior(WarriorID string) (*Warrior, error) {
 	var warriorEmail sql.NullString
 
 	e := d.db.QueryRow(
-		"SELECT id, name, email, rank, avatar, verified, notifications_enabled FROM warriors WHERE id = $1",
+		"SELECT id, name, email, rank, avatar, verified, notifications_enabled, jira_rest_api_token FROM warriors WHERE id = $1",
 		WarriorID,
 	).Scan(
 		&w.WarriorID,
@@ -51,6 +51,7 @@ func (d *Database) GetWarrior(WarriorID string) (*Warrior, error) {
 		&w.WarriorAvatar,
 		&w.Verified,
 		&w.NotificationsEnabled,
+		&w.JiraRestApiToken,
 	)
 	if e != nil {
 		log.Println(e)
@@ -65,7 +66,7 @@ func (d *Database) GetWarrior(WarriorID string) (*Warrior, error) {
 func (d *Database) GetWarriorByEmail(WarriorEmail string) (*Warrior, error) {
 	var w Warrior
 	e := d.db.QueryRow(
-		"SELECT id, name, email, rank, verified FROM warriors WHERE email = $1",
+		"SELECT id, name, email, rank, verified, jira_rest_api_token FROM warriors WHERE email = $1",
 		WarriorEmail,
 	).Scan(
 		&w.WarriorID,
@@ -73,6 +74,7 @@ func (d *Database) GetWarriorByEmail(WarriorEmail string) (*Warrior, error) {
 		&w.WarriorEmail,
 		&w.WarriorRank,
 		&w.Verified,
+		&w.JiraRestApiToken,
 	)
 	if e != nil {
 		log.Println(e)
@@ -88,7 +90,7 @@ func (d *Database) AuthWarrior(WarriorEmail string, WarriorPassword string) (*Wa
 	var passHash string
 
 	e := d.db.QueryRow(
-		`SELECT id, name, email, rank, password, avatar, verified FROM warriors WHERE email = $1`,
+		`SELECT id, name, email, rank, password, avatar, verified, jira_rest_api_token FROM warriors WHERE email = $1`,
 		WarriorEmail,
 	).Scan(
 		&w.WarriorID,
@@ -98,6 +100,7 @@ func (d *Database) AuthWarrior(WarriorEmail string, WarriorPassword string) (*Wa
 		&passHash,
 		&w.WarriorAvatar,
 		&w.Verified,
+		&w.JiraRestApiToken,
 	)
 	if e != nil {
 		log.Println(e)
@@ -166,16 +169,17 @@ func (d *Database) CreateWarriorCorporal(WarriorName string, WarriorEmail string
 }
 
 // UpdateWarriorProfile attempts to update the warriors profile
-func (d *Database) UpdateWarriorProfile(WarriorID string, WarriorName string, WarriorAvatar string, NotificationsEnabled bool) error {
+func (d *Database) UpdateWarriorProfile(WarriorID string, WarriorName string, WarriorAvatar string, NotificationsEnabled bool, JiraRestApiToken string) error {
 	if WarriorAvatar == "" {
 		WarriorAvatar = "identicon"
 	}
 	if _, err := d.db.Exec(
-		`UPDATE warriors SET name = $2, avatar = $3, notifications_enabled=$4 WHERE id = $1;`,
+		`UPDATE warriors SET name = $2, avatar = $3, notifications_enabled=$4, jira_rest_api_token=$5 WHERE id = $1;`,
 		WarriorID,
 		WarriorName,
 		WarriorAvatar,
 		NotificationsEnabled,
+		JiraRestApiToken,
 	); err != nil {
 		log.Println(err)
 		return errors.New("error attempting to update warriors profile")

--- a/routes.go
+++ b/routes.go
@@ -37,6 +37,8 @@ func (s *server) routes() {
 	// battle(s)
 	s.router.HandleFunc("/api/battle", s.handleBattleCreate()).Methods("POST")
 	s.router.HandleFunc("/api/battles", s.handleBattlesGet())
+	// jira rest
+	s.router.HandleFunc("/api/jira/tickets", s.handleGetJiraTickets())
 	// admin routes
 	s.router.HandleFunc("/api/admin/stats", s.adminOnly(s.handleAppStats()))
 	s.router.HandleFunc("/api/admin/warriors", s.adminOnly(s.handleGetRegisteredWarriors()))

--- a/schema.sql
+++ b/schema.sql
@@ -82,6 +82,8 @@ ALTER TABLE plans ADD COLUMN IF NOT EXISTS type VARCHAR(64) DEFAULT 'story';
 
 ALTER TABLE battles_warriors ADD COLUMN IF NOT EXISTS abandoned BOOL DEFAULT false;
 
+ALTER TABLE warriors ADD COLUMN IF NOT EXISTS jira_rest_api_token VARCHAR(128) DEFAULT '';
+
 --
 -- Types (used in Stored Procedures)
 --


### PR DESCRIPTION
Jira has a great REST API that allows the search for tickets (Stories, Bugs, ...) based on the JQL.
This PR adds the ability to "ask" Jira directly for tickets using the same JQL one would use to export tickets as XML.

By default the feature is disabled since it requires further configuration:
* pre-define the correct server URL (optional, if not set the user must change the dummy on the dialogue)
* Jira limits the amount of tickets in the REST response results to 50 - this can be set to a different value (default is 30)
* The "acceptance criteria" is a custom field in Jira (added by an extension) and needs to be configured here (e.g. as customfield_15023) - otherwise no acceptance criteria will show up

Advantage: I had several issues with the XML export since Jira does not generate error free XML in our cases - there was always something to fix before importing. The REST interface is pretty fast and requests only the few attributes that are required to setup a plan