### PR TITLE
Fix missing link error when importing Jira tickets during battle creation

### DIFF
--- a/frontend/src/components/CreateBattle.svelte
+++ b/frontend/src/components/CreateBattle.svelte
@@ -40,7 +40,7 @@
             name: newPlan.planName,
             type: newPlan.type,
             referenceId: newPlan.referenceId,
-            link: newPlan.Link,
+            link: newPlan.link,
             description: newPlan.description,
             acceptanceCriteria: newPlan.acceptanceCriteria,
         }


### PR DESCRIPTION
When importing Jira tickets on the "create battle" page the links were not stored. This only works when importing plans on the battle page.

I added it as separate PR so it can be merged independent from PR #124.