### PR TITLE
Add pagination to REST call so it returns all tickets from Jira

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -817,7 +817,7 @@ func (s *server) handleGetJiraTickets() http.HandlerFunc {
 		}
 		json.Unmarshal(body, &keyVal) // check for errors
 
-		api := keyVal.EndPoint + "/rest/api/2/search?jql="
+		api := keyVal.EndPoint + "/rest/api/2/search"
 
 		response := getListOfTickets(keyVal.UserName, keyVal.Password, api, keyVal.Jql)
 

--- a/jira-rest.go
+++ b/jira-rest.go
@@ -12,9 +12,21 @@ import (
 	"github.com/spf13/viper"
 )
 
+type JiraRequest struct {
+	Client     *http.Client
+	BaseUrl    string
+	EncodedJql string
+	Fields     string
+	MaxResults int
+	Username   string
+	Password   string
+}
+
 type Jira struct {
-	Total  int     `json:"total"`
-	Issues []Issue `json:"issues"`
+	StartAt    int     `json:"startAt"`
+	MaxResults int     `json:"maxResults"`
+	Total      int     `json:"total"`
+	Issues     []Issue `json:"issues"`
 }
 
 type Issue struct {
@@ -38,23 +50,23 @@ func encodeJql(jql string) string {
 	return url.QueryEscape(jql)
 }
 
-func createQueryParams() string {
+func createFieldsQueryParam() string {
 	nameFieldAcceptanceCriteria := viper.GetString("jira.acceptance_fieldname")
 	if nameFieldAcceptanceCriteria != "" {
 		nameFieldAcceptanceCriteria = "," + nameFieldAcceptanceCriteria
 	}
 	// limit fields to the few required to create a plan
-	fields := "&fields=summary,issuetype,description" + nameFieldAcceptanceCriteria
+	return "summary,issuetype,description" + nameFieldAcceptanceCriteria
+}
 
+func createMaxResultQueryParam() int {
 	limit := viper.GetInt("jira.limit")
 	if limit > 50 {
 		limit = 50
 	}
 
 	// limit the result to a maximum
-	maxResults := "&maxResults=" + strconv.Itoa(limit)
-	// send back combination all query parameters
-	return fields + maxResults
+	return limit
 }
 
 func simplifyResponse(bodyBytes []byte) []byte {
@@ -68,12 +80,54 @@ func simplifyResponse(bodyBytes []byte) []byte {
 }
 
 func getListOfTickets(username string, passwd string, url string, jql string) Jira {
-	var target = url + encodeJql(jql) + createQueryParams()
 
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", target, nil)
-	req.SetBasicAuth(username, passwd)
-	resp, err := client.Do(req)
+	// create request obj
+	jiraReq := JiraRequest{
+		Client:     &http.Client{},
+		BaseUrl:    url,
+		EncodedJql: encodeJql(jql),
+		Fields:     createFieldsQueryParam(),
+		MaxResults: createMaxResultQueryParam(),
+		Username:   username,
+		Password:   passwd,
+	}
+
+	main := processBundle(jiraReq, 0)
+
+	// check if more items need to be loaded (total > max results)
+	if main.Total > main.MaxResults {
+		// prepare paging and add issues
+		var bundles = main.Total / main.MaxResults
+		if main.Total%main.MaxResults == 0 {
+			bundles--
+		}
+
+		// load bundles unless all tickets are loaded
+		for bundle := 1; bundle <= bundles; bundle++ {
+			// calculate next startAt value
+			startAt := bundle * main.MaxResults
+			// get page from server
+			bundled := processBundle(jiraReq, startAt)
+			// replace
+			main.Issues = append(main.Issues, bundled.Issues...)
+		}
+	}
+	return main
+}
+
+func processBundle(jiraReq JiraRequest, startAt int) Jira {
+	req, err := http.NewRequest("GET", jiraReq.BaseUrl, nil)
+	req.SetBasicAuth(jiraReq.Username, jiraReq.Password)
+	// add query parameters
+	q := req.URL.Query()
+	q.Add("jql", jiraReq.EncodedJql)
+	q.Add("fields", jiraReq.Fields)
+	q.Add("maxResults", strconv.Itoa(jiraReq.MaxResults))
+	q.Add("startAt", strconv.Itoa(startAt))
+	// encode and assign back to the request
+	req.URL.RawQuery = q.Encode()
+	// send request to server
+	resp, err := jiraReq.Client.Do(req)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -86,4 +140,5 @@ func getListOfTickets(username string, passwd string, url string, jql string) Ji
 	json.Unmarshal(simpleResponse, &jiraRoot)
 
 	return jiraRoot
+
 }


### PR DESCRIPTION
Update to the Jira Rest client for #138:
Before adding pagination to the UI it is required to load all tickets for given JQL. Jira Rest API limits the maximum number of tickets returned in one request to 50. The configuration item `JIRA_LIMIT` defines the amount of tickets read in one bundle. The solution iterates the total amount of tickets unless all are loaded.