### PR TITLE
minor refactoring docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,45 +5,46 @@ services:
     build:
       context: .
       dockerfile: ./build/Dockerfile
+    restart: always
     ports:
       - "8080:8080"
     depends_on:
       - db
-    links:
-      - db
     networks:
-      - asgard
+      - asgard_mail
+      - asgard_db
     environment:
       APP_DOMAIN: ".127.0.0.1"
       COOKIE_SECURE: "false"
       SMTP_SECURE: "false"
       SMTP_HOST: mail
+      DB_NAME: thunderdome
+      DB_USER: thor
+      DB_PASS: odinson
     volumes:
-      - ./etc:/etc/thunderdome
+      - ./data/thunderdome:/etc/thunderdome
   db: 
-    image: postgres:latest
+    image: postgres:13.2
     restart: always
     environment:
       POSTGRES_DB: thunderdome
       POSTGRES_USER: thor
       POSTGRES_PASSWORD: odinson
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
     volumes:
-      - thunderdome_data:/var/lib/postgresql/data
+      - :/data/postgres:/var/lib/postgresql/data
     networks:
-      - asgard
+      - asgard_db
   mail:
-    image: djfarrelly/maildev:latest
+    image: djfarrelly/maildev:1.1.0
     restart: always
     ports:
       - 1080:80
       - 1025:25
     networks:
-      - asgard
+      - asgard_mail
 
 networks:
- asgard:
-
-volumes:
-  thunderdome_data:
+ asgard_mail:
+ asgard_db:


### PR DESCRIPTION
Hi,

thank you for the awesome project. Here are some changes I would like to propose for the docker-compose.yml. Priority High to Low:

* The Database ports do not need to be exposed by default. Use expose instead. Also port collision are no longer a thing then.
* Add the env vars for database config. This helps lazy people to not use default passwords.
* Use version tags instead of latest tags. This can break the project really quick. Once you do no longer maintain it, it will be difficult to understand which versions of postgres are still compatible. Also it will help to prevent un-reproducible bug reports, when people use whatever version.
* The Network can be split into two seperate networks. db does not need to talk to mail.
* Use either folder mounts or volumes mounts but not a mix. 
* etc is a "strange" name for the data of thunderdome. Use a more descriptive name.

What do you think about those changes?