### PR TITLE
Separate the basic translation from the specific (default/friendly)

### DIFF
--- a/frontend/public/lang/de.json
+++ b/frontend/public/lang/de.json
@@ -1,0 +1,350 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Version {version}",
+    "avatarAltText": "Avatar Platzhalter",
+    "logout": "Abmelden",
+    "battleEditPointsDisabled": "Sch\u00E4tzung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden.",
+    "save": "Speichern",
+    "warriorNudge": "Anstubsen",
+    "promote": "Bef\u00F6rdern",
+    "demote": "Degradieren",
+    "planAdd": "Plan hinzuf\u00FCgen",
+    "planSkip": "Plan \u00FCberspringen",
+    "planName": "Plan Name",
+    "planNamePlaceholder": "Plan Name eingeben",
+    "planType": "Plan Typ",
+    "planTypePlaceholder": "Typen",
+    "planLink": "Link",
+    "planLinkPlaceholder": "Link zum Plan eingeben",
+    "planLinkInvalid": "Der Link ist keine g\u00FCltige absolute URL, enth\u00E4lt z.B. das Protokol (HTTP/HTTPS)",
+    "planReferenceId": "Referenz ID",
+    "planReferenceIdPlaceholder": "Referenz ID eingeben",
+    "planDescription": "Beschreibung",
+    "planDescriptionPlaceholder": "Beschreibung eingeben",
+    "planAcceptanceCriteria": "Akzeptanzkriterien",
+    "planAcceptanceCriteriaPlaceholder": "Akzeptanzkriterien eingeben",
+    "pointed": "Gesch\u00E4tzt ({count})",
+    "unpointed": "Ungesch\u00E4tzt ({count})",
+    "view": "Anzeigen",
+    "activate": "Aktivieren",
+    "votingFinish": "Sch\u00E4tzung beenden",
+    "votingRestart": "Sch\u00E4tzung neu starten",
+    "importJiraXML": "Jira XML Import",
+    "importJiraXMLBadFileTypeError": "Fehler: falscher Datei-Typ",
+    "importJiraXMLReadFileError": "Fehler beim Lesen der Datei",
+    "planTypeStory": "Story",
+    "planTypeBug": "Bug",
+    "planTypeSpike": "Spike",
+    "planTypeEpic": "Epic",
+    "planTypeTask": "Task",
+    "planTypeSubtask": "Subtask",
+    "landingTitle": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
+    "landingBullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
+    "landingBullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
+    "landingFeatures": "Eigenschaften",
+    "landingFeatureOpenSourceTitle": "Open Source",
+    "landingFeatureOpenSourceText": "Check out the {repoOpen}repository{repoClose} to request or contribute enhancements, locale translations and bug fixes or to {donateOpen}Donate{donateClose}",
+    "pages": {
+        "myBattles": {
+            "countPlansPointed": "{totalPointed} von {totalPlans} Pl\u00E4nen gesch\u00E4tzt",
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Zul\u00E4ssige Sch\u00E4tzwerte"
+                    },
+                    "plans": {
+                        "label": "Pl\u00E4ne",
+                        "addButton": "Hinzuf\u00FCgen",
+                        "removeButton": "Entfernen",
+                        "fields": {
+                            "name": {
+                                "placeholder": "Name f\u00FCr den Plan eingeben"
+                            }
+                        }
+                    },
+                    "averageRounding": {
+                        "label": "Methode zur Rundung des Punkteschnitts",
+                        "ceil": "Aufrunden",
+                        "floor": "Abrunden",
+                        "round": "Kaufm. Runden"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Konto erstellen",
+            "registrationDisabled": "Registrierung ist deaktiviert.",
+            "guestForm": {
+                "title": "Als Gast teilnehmen",
+                "saveButton": "Teilnehmen",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Name eingeben"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Erstellen",
+                "title": "Konto erstellen {optionalOpen}(optional){optionalClose}",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Name eingeben"
+                    },
+                    "email": {
+                        "label": "E-Mail",
+                        "placeholder": "E-Mail eingeben"
+                    },
+                    "password": {
+                        "label": "Passwort",
+                        "placeholder": "Passwort eingeben"
+                    },
+                    "confirmPassword": {
+                        "label": "Passwort best\u00E4tigen",
+                        "placeholder": "Passwort best\u00E4tigen"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Konto\u00FCberpr\u00FCfung...",
+            "verified": {
+                "title": "Konto \u00FCberpr\u00FCft",
+                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail-Adresse."
+            },
+            "failed": {
+                "title": "\u00DCberpr\u00FCfung fehlgeschlagen",
+                "error": "Bei der \u00DCberpr\u00FCfung des Kontos ist ein Fehler aufgetreten. M\u00F6glicherweise ist dieser Link abgelaufen oder wurde bereits verwendet."
+            }
+        },
+        "warriorProfile": {
+            "title": "Profil",
+            "errorRetreiving": "Beim Laden des Profils ist ein Fehler aufgetreten",
+            "errorUpdating": "Beim Aktualisieren des Profils ist ein Fehler aufgetreten",
+            "updateSuccess": "Profil aktualisiert",
+            "passwordUpdated": "Passwort aktualisiert",
+            "passwordUpdateError": "Beim Versuch, das Kennwort zu aktualisieren, ist ein Fehler aufgetreten",
+            "updatePasswordButton": "Passwort \u00E4ndern",
+            "saveProfileButton": "Profil aktualisieren",
+            "fields": {
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Name eingeben"
+                },
+                "email": {
+                    "label": "E-Mail",
+                    "verified": "Best\u00E4tigt"
+                },
+                "country": {
+                    "label": "Land",
+                    "placeholder": "Land w\u00E4hlen (optional)"
+                },
+                "company": {
+                    "label": "Firma",
+                    "placeholder": "Firma eingeben (optional)"
+                },
+                "jobTitle": {
+                    "label": "Berufsbezeichnung",
+                    "placeholder": "Berufsbezeichnung eingeben (optional)"
+                },
+                "avatar": {
+                    "label": "Avatar"
+                },
+                "enable_notifications": {
+                    "label": "Benachrichtigungen aktivieren"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Passwort \u00E4ndern",
+                "cancelButton": "Abbruch",
+                "saveButton": "Speichern",
+                "fields": {
+                    "password": {
+                        "label": "Passwort",
+                        "placeholder": "Passwort eingeben"
+                    },
+                    "confirmPassword": {
+                        "label": "Passwort best\u00E4tigen",
+                        "placeholder": "Passwort best\u00E4tigen"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Key",
+                "createButton": "API Key erstellen",
+                "name": "Key Name",
+                "prefix": "Key Pr\u00E4fix",
+                "active": "Aktiv",
+                "updated": "Zuletzt aktualisiert",
+                "actions": "Aktionen",
+                "activateButton": "Aktivieren",
+                "deactivateButton": "Deaktivieren",
+                "deleteButton": "L\u00F6schen",
+                "errorRetreiving": "API keys konnten nicht abgerufen werden ",
+                "createFailed": "API Key konnte nicht erstellt werden",
+                "deleteFailed": "API Key konnte nicht gel\u00F6scht werden",
+                "deleteSuccess": "API Key gel\u00F6scht",
+                "updateSuccess": "API Key aktualisiert",
+                "updateFailed": "API Key konnte nicht aktualisiert werden",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Key Name eingeben",
+                        "invalid": "Bitte einen Key Namen angeben"
+                    },
+                    "submitButton": "Erstellen",
+                    "closeButton": "Schlie\u00dfen"
+                },
+                "createSuccess": "Neuer Api Key {keyName} erstellt und {onlyNowOpen}dieser wird nur jetzt angezeigt{onlyNowClose}",
+                "storeWarning": "Bitte den Api Key an einem sicheren Ort aufbewahren, da dieses generierte Token nicht mehr abgerufen oder wiederhergestellt werden kann, sobald diese Seite verlassen wurde."
+            },
+            "delete": {
+                "deleteButton": "Konto l\u00F6schen",
+                "error": "Es ist ein Fehler beim L\u00F6schen des Kontos aufgetreten.",
+                "warningStatement": "Konto wirklich l\u00F6schen? Dies kann nicht R\u00FCckg\u00E4ngig gemacht werden.",
+                "confirmButton": "L\u00F6schen best\u00E4tigen",
+                "cancelButton": "Abbruch"
+            }
+        },
+        "admin": {
+            "nav": "Verwaltung",
+            "title": "Verwaltung",
+            "counts": {
+                "plans": "Pl\u00E4ne"
+            },
+            "registeredWarriors": {
+                "name": "Name",
+                "email": "E-Mail",
+                "country": "Land",
+                "company": "Firma",
+                "jobTitle": "Berufsbezeichnung",
+                "verified": "Best\u00E4tigt",
+                "rank": "Rang"
+            },
+            "maintenance": {
+                "title": "Wartung",
+                "cleanGuests": "Entferne G\u00E4ste \u00E4lter als {daysOld} Tage"
+            }
+        },
+        "login": {
+            "nav": "Anmeldung",
+            "title": "Anmeldung",
+            "button": "Anmelden",
+            "sendResetSuccess": "Anweisungen zum Zur\u00FCcksetzen des Passworts wurden an {email} gesendet",
+            "sendResetError": "Beim Senden der E-Mail zum Zur\u00FCcksetzen ist ein Fehler aufgetreten",
+            "fields": {
+                "email": {
+                    "label": "E-Mail",
+                    "placeholder": "E-Mail eingeben"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Passwort eingeben",
+                    "forgotLabel": "Passwort vergessen?"
+                }
+            },
+            "passwordReset": {
+                "title": "Passwort zur\u00FCcksetzen",
+                "resetError": "Fehler beim Versuch, das Passwort zur\u00FCckzusetzen",
+                "saveButton": "Zur\u00FCcksetzen",
+                "fields": {
+                    "password": {
+                        "label": "Passwort",
+                        "placeholder": "Passwort eingeben"
+                    },
+                    "confirmPassword": {
+                        "label": "Passwort best\u00E4tigen",
+                        "placeholder": "Passwort eingeben"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "votingNotStarted": "Sch\u00E4tzung noch nicht gestartet",
+            "warriorVoted": "{name} hat eine Sch\u00E4tzung abegeben",
+            "warriorRetractedVote": "{name} hat die Sch\u00E4tzung zur\u00FCckgezogen",
+            "warriorNudge": "pst... {name}, wir warten auf eine Sch\u00E4tzung",
+            "warriorLeader": "Chef",
+            "finalPoints": "Finale Punkte",
+            "points": "Punkte",
+            "planSkipped": "Plan \u00FCbersprungen",
+            "voteResults": {
+                "totalVotes": "Sch\u00E4tzungen",
+                "average": "Durchschnitt",
+                "highest": "H\u00F6chster",
+                "showVoters": "Zeige Sch\u00E4tzer"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "Der Source Code ist lizensiert {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Erstellt mit {svelteOpen}Svelte{svelteClose} und {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "E-Mail",
+    "plans": "Pl\u00E4ne",
+    "cancel": "Abbruch",
+    "delete": "L\u00F6schen",
+    "edit": "Bearbeiten",
+    "users": "Benutzer",
+    "type": "Typ",
+    "active": "Aktiv",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Aktualisierungsdatum",
+    "dateCreated": "Erstellungsdatum",
+    "cannotBeUndone": "Das kann nicht r\u00FCckg\u00E4ngig gemacht werden.",
+    "userEmail": "Benutzer E-Mail",
+    "userEmailPlaceholder": "E-Mail-Adresse eines registrierten Benutzers eingeben",
+    "userAddSuccess": "Benutzer erfolgreich hinzugef\u00FCgt.",
+    "userAddError": "Fehler beim Versuch, den Benutzer anzulegen.",
+    "userRemoveSuccess": "Benutzer erfolgreich entfernt.",
+    "userRemoveError": "Fehler beim Versuch, den Benutzer zu entfernen.",
+    "role": "Rolle",
+    "rolePlaceholder": "Benutzerrolle ausw\u00E4hlen",
+    "userAdd": "Benutzer hinzuf\u00FCgen",
+    "flag": "Flag",
+    "alerts": "Benachrichtigungen",
+    "alertCreate": "Benachrichtigung erstellen",
+    "alertNamePlaceholder": "Name f\u00FCr die Benachrichtigung eingeben",
+    "alertTypePlaceholder": "Benachrichtigungstyp ausw\u00E4hlen",
+    "alertContent": "Benachrichtigungsinhalt",
+    "alertContentPlaceholder": "Benachrichtigungsinhalt eingeben",
+    "alertRegisteredOnly": "Nur registrierte",
+    "alertAllowDismiss": "Ablehnen zulassen",
+    "alertSave": "Benachrichtigung speichern",
+    "alertDelete": "Benachrichtigung l\u00F6schen",
+    "alertDeleteConfirmation": "Diese Benachrichtigung wirklich l\u00F6schen?",
+    "department": "Abteilung",
+    "departments": "Abteilungen",
+    "departmentCreate": "Abteilung anlegen",
+    "departmentName": "Abteilungsname",
+    "departmentNamePlaceholder": "Abteilungsname angeben",
+    "departmentSave": "Abteilung speichern",
+    "departmentGetError": "Fehler beim Ermitteln der Abteilung",
+    "departmentUsersGetError": "Fehler beim Ermitteln der Benutzer der Abteilung",
+    "departmentTeamsGetError": "Fehler beim Ermitteln der Teams der Abteilung",
+    "departmentCreateError": "Fehler beim Erstellen der Abteilung",
+    "organization": "Unternehmen",
+    "organizations": "Unternehmen",
+    "organizationName": "Unternehmensname",
+    "organizationNamePlaceholder": "Unternehmensname angeben",
+    "organizationSave": "Unternehmen speichern",
+    "organizationGetError": "Fehler beim Ermitteln des Unternehmens",
+    "organizationGetDepartmentsError": "Fehler beim Ermitteln der Unternehmens-Abteilungen",
+    "organizationGetTeamsError": "Fehler beim Ermitteln der Teams des Unternehmens",
+    "organizationGetUsersError": "Fehler beim Ermitteln der Benutzer des Unternehmens",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Team erstellen",
+    "teamCreateSuccess": "Team erfolgreich angelegt.",
+    "teamCreateError": "Fehler beim Erstellen des Teams.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Team Name angeben",
+    "teamSave": "Team speichern",
+    "teamDeleteSuccess": "Team erfolgreich gel\u00F6scht",
+    "teamDeleteError": "Fehler beim L\u00F6schen des Teams",
+    "teamGetError": "Fehler beim Ermitteln des Teams",
+    "teamGetUsersError": "Fehler beim Ermitteln der Benutzer des Teams"
+}

--- a/frontend/public/lang/de.json
+++ b/frontend/public/lang/de.json
@@ -353,5 +353,6 @@
     "adminPageAlerts": "Benachrichtigungen",
     "adminPageOrganizations": "Unternehmen",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Benutzer"
+    "adminPageUsers": "Benutzer",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/de.json
+++ b/frontend/public/lang/de.json
@@ -288,6 +288,7 @@
     "plans": "Pl\u00E4ne",
     "cancel": "Abbruch",
     "delete": "L\u00F6schen",
+    "remove": "Entfernen",
     "edit": "Bearbeiten",
     "users": "Benutzer",
     "type": "Typ",
@@ -347,5 +348,10 @@
     "teamDeleteSuccess": "Team erfolgreich gel\u00F6scht",
     "teamDeleteError": "Fehler beim L\u00F6schen des Teams",
     "teamGetError": "Fehler beim Ermitteln des Teams",
-    "teamGetUsersError": "Fehler beim Ermitteln der Benutzer des Teams"
+    "teamGetUsersError": "Fehler beim Ermitteln der Benutzer des Teams",
+    "adminPageAdmin": "Allgemein",
+    "adminPageAlerts": "Benachrichtigungen",
+    "adminPageOrganizations": "Unternehmen",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Benutzer"
 }

--- a/frontend/public/lang/de.json
+++ b/frontend/public/lang/de.json
@@ -40,6 +40,7 @@
     "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
     "landingBullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
+    "landingBullet3": "Funktioniert mit allen {mbOpen}modernen Browsern*{mbClose}, inklusive Mobile",
     "landingBullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
     "landingFeatures": "Eigenschaften",
     "landingFeatureOpenSourceTitle": "Open Source",

--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -1,62 +1,18 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Avatar Platzhalter",
-    "logout": "Abmelden",
     "logoutError": "Fehler beim Abmelden des Kriegers",
     "battleDelete": "Schlacht l\u00F6schen",
     "battleAbandon": "Schlacht verlassen",
     "battleCreate": "Schlacht erstellen",
     "battleEdit": "Schlacht bearbeiten",
-    "battleEditPointsDisabled": "Sch\u00E4tzung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden.",
-    "save": "Speichern",
     "warriorCreate": "Krieger erstellen",
-    "warriorNudge": "Anstubsen",
-    "promote": "Bef\u00F6rdern",
-    "demote": "Degradieren",
-    "planAdd": "Plan hinzuf\u00FCgen",
-    "planSkip": "Plan \u00FCberspringen",
-    "planName": "Plan Name",
-    "planNamePlaceholder": "Plan Name eingeben",
-    "planType": "Plan Typ",
-    "planTypePlaceholder": "Typen",
-    "planLink": "Link",
-    "planLinkPlaceholder": "Link zum Plan eingeben",
-    "planLinkInvalid": "Der Link ist keine g\u00FCltige absolute URL, enth\u00E4lt z.B. das Protokol (HTTP/HTTPS)",
-    "planReferenceId": "Referenz ID",
-    "planReferenceIdPlaceholder": "Referenz ID eingeben",
-    "planDescription": "Beschreibung",
-    "planDescriptionPlaceholder": "Beschreibung eingeben",
-    "planAcceptanceCriteria": "Akzeptanzkriterien",
-    "planAcceptanceCriteriaPlaceholder": "Akzeptanzkriterien eingeben",
-    "pointed": "Gesch\u00E4tzt ({count})",
-    "unpointed": "Ungesch\u00E4tzt ({count})",
-    "view": "Anzeigen",
-    "activate": "Aktivieren",
-    "votingFinish": "Sch\u00E4tzung beenden",
-    "votingRestart": "Sch\u00E4tzung neu starten",
-    "importJiraXML": "Jira XML Import",
-    "importJiraXMLBadFileTypeError": "Fehler: falscher Datei-Typ",
-    "importJiraXMLReadFileError": "Fehler beim Lesen der Datei",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
-    "landingTitle": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
-    "landingBullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
     "landingBullet2": "Einfache {crossoutOpen}Benutzer{crossoutClose}Krieger-Erfahrung",
     "landingBullet3": "Funktioniert mit allen {mbOpen}modernen Browsern*{mbClose}, inklusive Mobile",
-    "landingBullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
-    "landingFeatures": "Eigenschaften",
     "landingCountries": "Krieger in \u00FCber {count} L\u00E4ndern",
     "pages": {
         "myBattles": {
             "nav": "Meine Schlachten",
             "title": "Meine Schlachten",
             "battlesError": "Fehler: Keine Schlacht gefunden",
-            "countPlansPointed": "{totalPointed} von {totalPlans} Pl\u00E4nen gesch\u00E4tzt",
             "createBattle": {
                 "title": "Schlacht erstellen",
                 "createError": "Fehler beim Erstellen einer Schlacht",
@@ -65,229 +21,37 @@
                         "label": "Name der Schlacht",
                         "placeholder": "Name der Schlacht eingeben"
                     },
-                    "allowedPointValues": {
-                        "label": "Zul\u00E4ssige Sch\u00E4tzwerte"
-                    },
-                    "plans": {
-                        "label": "Pl\u00E4ne",
-                        "addButton": "Hinzuf\u00FCgen",
-                        "removeButton": "Entfernen",
-                        "fields": {
-                            "name": {
-                                "placeholder": "Name f\u00FCr den Plan eingeben"
-                            }
-                        }
-                    },
                     "autoFinishVoting": {
                         "label": "Sch\u00E4tzung automatisch beenden, wenn alle Krieger gesch\u00E4tzt haben"
-                    },
-                    "averageRounding": {
-                        "label": "Methode zur Rundung des Punkteschnitts",
-                        "ceil": "Aufrunden",
-                        "floor": "Abrunden",
-                        "round": "Kaufm. Runden"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Konto erstellen",
             "title": "Der Schlacht beitreten",
-            "registrationDisabled": "Registrierung ist deaktiviert.",
             "guestForm": {
-                "title": "Als Gast teilnehmen",
-                "saveButton": "Teilnehmen",
-                "createError": "Beim Registrieren als Gast-Krieger ist ein Fehler aufgetreten",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Name eingeben"
-                    }
-                }
+                "createError": "Beim Registrieren als Gast-Krieger ist ein Fehler aufgetreten"
             },
             "createAccountForm": {
-                "saveButton": "Erstellen",
-                "title": "Konto erstellen {optionalOpen}(optional){optionalClose}",
-                "createError": "Beim Erstellen des Kriegers ist ein Fehler aufgetreten",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Name eingeben"
-                    },
-                    "email": {
-                        "label": "E-Mail",
-                        "placeholder": "E-Mail eingeben"
-                    },
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort best\u00E4tigen"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Konto\u00FCberpr\u00FCfung...",
-            "verified": {
-                "title": "Konto \u00FCberpr\u00FCft",
-                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail-Adresse."
-            },
-            "failed": {
-                "title": "\u00DCberpr\u00FCfung fehlgeschlagen",
-                "error": "Bei der \u00DCberpr\u00FCfung des Kontos ist ein Fehler aufgetreten. M\u00F6glicherweise ist dieser Link abgelaufen oder wurde bereits verwendet."
-            }
-        },
-        "warriorProfile": {
-            "title": "Profil",
-            "errorRetreiving": "Beim Laden des Profils ist ein Fehler aufgetreten",
-            "errorUpdating": "Beim Aktualisieren des Profils ist ein Fehler aufgetreten",
-            "updateSuccess": "Profil aktualisiert",
-            "passwordUpdated": "Passwort aktualisiert",
-            "passwordUpdateError": "Beim Versuch, das Kennwort zu aktualisieren, ist ein Fehler aufgetreten",
-            "updatePasswordButton": "Passwort \u00E4ndern",
-            "saveProfileButton": "Profil aktualisieren",
-            "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Name eingeben"
-                },
-                "email": {
-                    "label": "E-Mail",
-                    "verified": "Best\u00E4tigt"
-                },
-                "country": {
-                    "label": "Land",
-                    "placeholder": "Land w\u00E4hlen (optional)"
-                },
-                "company": {
-                    "label": "Firma",
-                    "placeholder": "Firma eingeben (optional)"
-                },
-                "jobTitle": {
-                    "label": "Berufsbezeichnung",
-                    "placeholder": "Berufsbezeichnung eingeben (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
-                "enable_notifications": {
-                    "label": "Benachrichtigungen aktivieren"
-                }
-            },
-            "updatePasswordForm": {
-                "title": "Passwort \u00E4ndern",
-                "cancelButton": "Abbruch",
-                "saveButton": "Speichern",
-                "fields": {
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort best\u00E4tigen"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Key",
-                "createButton": "API Key erstellen",
-                "name": "Key Name",
-                "prefix": "Key Pr\u00E4fix",
-                "active": "Aktiv",
-                "updated": "Zuletzt aktualisiert",
-                "actions": "Aktionen",
-                "activateButton": "Aktivieren",
-                "deactivateButton": "Deaktivieren",
-                "deleteButton": "L\u00F6schen",
-                "errorRetreiving": "API keys konnten nicht abgerufen werden ",
-                "createFailed": "API Key konnte nicht erstellt werden",
-                "deleteFailed": "API Key konnte nicht gel\u00F6scht werden",
-                "deleteSuccess": "API Key gel\u00F6scht",
-                "updateSuccess": "API Key aktualisiert",
-                "updateFailed": "API Key konnte nicht aktualisiert werden",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Key Name eingeben",
-                        "invalid": "Bitte einen Key Namen angeben"
-                    },
-                    "submitButton": "Erstellen",
-                    "closeButton": "Schlie\u00dfen"
-                },
-                "createSuccess": "Neuer Api Key {keyName} erstellt und {onlyNowOpen}dieser wird nur jetzt angezeigt{onlyNowClose}",
-                "storeWarning": "Bitte den Api Key an einem sicheren Ort aufbewahren, da dieses generierte Token nicht mehr abgerufen oder wiederhergestellt werden kann, sobald diese Seite verlassen wurde."
-            },
-            "delete": {
-                "deleteButton": "Konto l\u00F6schen",
-                "error": "Es ist ein Fehler beim L\u00F6schen des Kontos aufgetreten.",
-                "warningStatement": "Konto wirklich l\u00F6schen? Dies kann nicht R\u00FCckg\u00E4ngig gemacht werden.",
-                "confirmButton": "L\u00F6schen best\u00E4tigen",
-                "cancelButton": "Abbruch"
+                "createError": "Beim Erstellen des Kriegers ist ein Fehler aufgetreten"
             }
         },
         "admin": {
-            "nav": "Verwaltung",
-            "title": "Verwaltung",
             "counts": {
                 "registered": "Registrierte Krieger",
                 "unregistered": "Nicht registrierte Krieger",
-                "battles": "Schlachten",
-                "plans": "Pl\u00E4ne"
+                "battles": "Schlachten"
             },
             "registeredWarriors": {
-                "title": "Registrierte Krieger",
-                "name": "Name",
-                "email": "E-Mail",
-                "country": "Land",
-                "company": "Firma",
-                "jobTitle": "Berufsbezeichnung",
-                "verified": "Best\u00E4tigt",
-                "rank": "Rang"
+                "title": "Registrierte Krieger"
             },
             "maintenance": {
-                "title": "Wartung",
-                "cleanGuests": "Entferne G\u00E4ste \u00E4lter als {daysOld} Tage",
                 "cleanBattles": "Entferne Schlachten \u00E4lter als {daysOld} Tage"
             }
         },
         "login": {
-            "nav": "Anmeldung",
-            "title": "Anmeldung",
             "registerForBattle": "oder {registerOpen}Anmeldung{registerClose}, um der Schlacht beizutreten",
-            "button": "Anmelden",
-            "authError": "Beim Versuch, den Krieger zu authentifizieren, ist ein Fehler aufgetreten",
-            "sendResetSuccess": "Anweisungen zum Zur\u00FCcksetzen des Passworts wurden an {email} gesendet",
-            "sendResetError": "Beim Senden der E-Mail zum Zur\u00FCcksetzen ist ein Fehler aufgetreten",
-            "fields": {
-                "email": {
-                    "label": "E-Mail",
-                    "placeholder": "E-Mail eingeben"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Passwort eingeben",
-                    "forgotLabel": "Passwort vergessen?"
-                }
-            },
-            "passwordReset": {
-                "title": "Passwort zur\u00FCcksetzen",
-                "resetError": "Fehler beim Versuch, das Passwort zur\u00FCckzusetzen",
-                "saveButton": "Zur\u00FCcksetzen",
-                "fields": {
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort eingeben"
-                    }
-                }
-            }
+            "authError": "Beim Versuch, den Krieger zu authentifizieren, ist ein Fehler aufgetreten"
         },
         "battle": {
             "title": "Schlacht",
@@ -295,66 +59,15 @@
             "socketReconnecting": "Ooops, Schlachtpl\u00E4ne werden neu geladen...",
             "socketError": "Fehler beim Eintritt in die Schlacht, bitte aktualisieren und nochmals versuchen.",
             "loading": "Lade Schlachtpl\u00E4ne...",
-            "votingNotStarted": "Sch\u00E4tzung noch nicht gestartet",
             "warriorJoined": "{name} hat das Schlachtfeld betreten",
             "warriorRetreated": "{name} hat das Schlachtfeld verlassen",
-            "warriorVoted": "{name} hat eine Sch\u00E4tzung abegeben",
-            "warriorRetractedVote": "{name} hat die Sch\u00E4tzung zur\u00FCckgezogen",
-            "warriorNudge": "pst... {name}, wir warten auf eine Sch\u00E4tzung",
             "warriorInvite": "Krieger einladen",
-            "warriorLeader": "Chef",
-            "finalPoints": "Finale Punkte",
-            "points": "Punkte",
-            "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
-                "totalVotes": "Sch\u00E4tzungen",
-                "average": "Durchschnitt",
-                "highest": "H\u00F6chster",
-                "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Krieger"
             },
             "battleDeleted": "Schlacht gel\u00F6scht"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "Der Source Code ist lizensiert {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Erstellt mit {svelteOpen}Svelte{svelteClose} und {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "E-Mail",
-    "plans": "Pl\u00E4ne",
-    "cancel": "Abbruch",
-    "delete": "L\u00F6schen",
-    "edit": "Bearbeiten",
-    "users": "Benutzer",
-    "type": "Typ",
-    "active": "Aktiv",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Aktualisierungsdatum",
-    "dateCreated": "Erstellungsdatum",
-    "cannotBeUndone": "Das kann nicht r\u00FCckg\u00E4ngig gemacht werden.",
-    "userEmail": "Benutzer E-Mail",
-    "userEmailPlaceholder": "E-Mail-Adresse eines registrierten Benutzers eingeben",
-    "userAddSuccess": "Benutzer erfolgreich hinzugef\u00FCgt.",
-    "userAddError": "Fehler beim Versuch, den Benutzer anzulegen.",
-    "userRemoveSuccess": "Benutzer erfolgreich entfernt.",
-    "userRemoveError": "Fehler beim Versuch, den Benutzer zu entfernen.",
-    "role": "Rolle",
-    "rolePlaceholder": "Benutzerrolle ausw\u00E4hlen",
-    "userAdd": "Benutzer hinzuf\u00FCgen",
-    "flag": "Flag",
-    "alerts": "Benachrichtigungen",
-    "alertCreate": "Benachrichtigung erstellen",
-    "alertNamePlaceholder": "Name f\u00FCr die Benachrichtigung eingeben",
-    "alertTypePlaceholder": "Benachrichtigungstyp ausw\u00E4hlen",
-    "alertContent": "Benachrichtigungsinhalt",
-    "alertContentPlaceholder": "Benachrichtigungsinhalt eingeben",
-    "alertRegisteredOnly": "Nur registrierte",
-    "alertAllowDismiss": "Ablehnen zulassen",
-    "alertSave": "Benachrichtigung speichern",
-    "alertDelete": "Benachrichtigung l\u00F6schen",
-    "alertDeleteConfirmation": "Diese Benachrichtigung wirklich l\u00F6schen?",
     "battle": "Schlacht",
     "battles": "Schlachten",
     "battlesActive": "Aktive Schlachten",
@@ -362,37 +75,6 @@
     "battleJoin": "Schlacht beitreten",
     "battleRemoveSuccess": "Schlacht erfolgreich entfernt.",
     "battleRemoveError": "Fehler beim Entfernen der Schlacht aufgetreten.",
-    "department": "Abteilung",
-    "departments": "Abteilungen",
-    "departmentCreate": "Abteilung anlegen",
-    "departmentName": "Abteilungsname",
-    "departmentNamePlaceholder": "Abteilungsname angeben",
-    "departmentSave": "Abteilung speichern",
-    "departmentGetError": "Fehler beim Ermitteln der Abteilung",
-    "departmentUsersGetError": "Fehler beim Ermitteln der Benutzer der Abteilung",
-    "departmentTeamsGetError": "Fehler beim Ermitteln der Teams der Abteilung",
-    "departmentCreateError": "Fehler beim Erstellen der Abteilung",
-    "organization": "Unternehmen",
-    "organizations": "Unternehmen",
-    "organizationName": "Unternehmensname",
-    "organizationNamePlaceholder": "Unternehmensname angeben",
-    "organizationSave": "Unternehmen speichern",
-    "organizationGetError": "Fehler beim Ermitteln des Unternehmens",
-    "organizationGetDepartmentsError": "Fehler beim Ermitteln der Unternehmens-Abteilungen",
-    "organizationGetTeamsError": "Fehler beim Ermitteln der Teams des Unternehmens",
-    "organizationGetUsersError": "Fehler beim Ermitteln der Benutzer des Unternehmens",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Team erstellen",
-    "teamCreateSuccess": "Team erfolgreich angelegt.",
-    "teamCreateError": "Fehler beim Erstellen des Teams.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Team Name angeben",
-    "teamSave": "Team speichern",
-    "teamDeleteSuccess": "Team erfolgreich gel\u00F6scht",
-    "teamDeleteError": "Fehler beim L\u00F6schen des Teams",
-    "teamGetError": "Fehler beim Ermitteln des Teams",
-    "teamGetUsersError": "Fehler beim Ermitteln der Benutzer des Teams",
     "teamGetBattlesError": "Fehler beim Ermitteln der Schlachten des Teams",
     "sessionDuplicate": "Es existiert bereits eine Schlacht-Sitzung f\u00FCr Ihre ID"
 }

--- a/frontend/public/lang/default/de.json
+++ b/frontend/public/lang/default/de.json
@@ -6,7 +6,6 @@
     "battleEdit": "Schlacht bearbeiten",
     "warriorCreate": "Krieger erstellen",
     "landingBullet2": "Einfache {crossoutOpen}Benutzer{crossoutClose}Krieger-Erfahrung",
-    "landingBullet3": "Funktioniert mit allen {mbOpen}modernen Browsern*{mbClose}, inklusive Mobile",
     "landingCountries": "Krieger in \u00FCber {count} L\u00E4ndern",
     "pages": {
         "myBattles": {

--- a/frontend/public/lang/default/en.json
+++ b/frontend/public/lang/default/en.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout warrior",
     "battleDelete": "Delete Battle",
     "battleAbandon": "Abandon Battle",
     "battleCreate": "Create Battle",
     "battleEdit": "Edit Battle",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create Warrior",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Plan",
     "planSkip": "Skip Plan",
     "planName": "Plan Name",
     "planNamePlaceholder": "Enter a plan name",
     "planType": "Plan Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to plan",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import plans from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app with a fun theme",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple {crossoutOpen}User{crossoutClose}Warrior Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Warriors in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Battle Name",
                         "placeholder": "Enter a battle name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Plans",
                         "addButton": "Add Plan",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a plan name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Warriors have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Enlist to Battle",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering warrior as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering warrior as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating warrior",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating warrior"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable battle notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Warriors",
                 "unregistered": "Unregistered Warriors",
@@ -239,55 +68,15 @@
                 "plans": "Plans"
             },
             "registeredWarriors": {
-                "title": "Registered Warriors",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Warriors"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Battles older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Battle",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate warrior",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate warrior"
         },
         "battle": {
             "title": "Battle",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Battle Plans...",
             "socketError": "Error joining battle, refresh and try again.",
             "loading": "Loading Battle Plans...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the battle",
             "warriorRetreated": "{name} has retreated from the battle",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Warrior",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
             "planSkipped": "Plan skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Warrior"
             },
             "battleDeleted": "Battle deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Plans",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Battle",
     "battles": "Battles",
     "battlesActive": "Active Battles",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Battle",
     "battleRemoveSuccess": "Battle removed successfully.",
     "battleRemoveError": "Error attempting to remove battle.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team battles",
     "sessionDuplicate": "Duplicate battle session exists for your ID"
 }

--- a/frontend/public/lang/default/es.json
+++ b/frontend/public/lang/default/es.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout warrior",
     "battleDelete": "Delete Battle",
     "battleAbandon": "Abandon Battle",
     "battleCreate": "Create Battle",
     "battleEdit": "Edit Battle",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create Warrior",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Plan",
     "planSkip": "Skip Plan",
     "planName": "Plan Name",
     "planNamePlaceholder": "Enter a plan name",
     "planType": "Plan Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to plan",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import plans from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app with a fun theme",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple {crossoutOpen}User{crossoutClose}Warrior Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Warriors in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Battle Name",
                         "placeholder": "Enter a battle name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Plans",
                         "addButton": "Add Plan",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a plan name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Warriors have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Enlist to Battle",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering warrior as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering warrior as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating warrior",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating warrior"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable battle notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Warriors",
                 "unregistered": "Unregistered Warriors",
@@ -239,55 +68,15 @@
                 "plans": "Plans"
             },
             "registeredWarriors": {
-                "title": "Registered Warriors",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Warriors"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Battles older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Battle",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate warrior",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate warrior"
         },
         "battle": {
             "title": "Battle",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Battle Plans...",
             "socketError": "Error joining battle, refresh and try again.",
             "loading": "Loading Battle Plans...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the battle",
             "warriorRetreated": "{name} has retreated from the battle",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Warrior",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
             "planSkipped": "Plan skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Warrior"
             },
             "battleDeleted": "Battle deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Plans",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Battle",
     "battles": "Battles",
     "battlesActive": "Active Battles",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Battle",
     "battleRemoveSuccess": "Battle removed successfully.",
     "battleRemoveError": "Error attempting to remove battle.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team battles",
     "sessionDuplicate": "Duplicate battle session exists for your ID"
 }

--- a/frontend/public/lang/default/fr.json
+++ b/frontend/public/lang/default/fr.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout warrior",
     "battleDelete": "Delete Battle",
     "battleAbandon": "Abandon Battle",
     "battleCreate": "Create Battle",
     "battleEdit": "Edit Battle",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create Warrior",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Plan",
     "planSkip": "Skip Plan",
     "planName": "Plan Name",
     "planNamePlaceholder": "Enter a plan name",
     "planType": "Plan Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to plan",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import plans from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app with a fun theme",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple {crossoutOpen}User{crossoutClose}Warrior Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Warriors in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Battle Name",
                         "placeholder": "Enter a battle name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Plans",
                         "addButton": "Add Plan",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a plan name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Warriors have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Enlist to Battle",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering warrior as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering warrior as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating warrior",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating warrior"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable battle notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Warriors",
                 "unregistered": "Unregistered Warriors",
@@ -239,55 +68,15 @@
                 "plans": "Plans"
             },
             "registeredWarriors": {
-                "title": "Registered Warriors",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Warriors"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Battles older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Battle",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate warrior",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate warrior"
         },
         "battle": {
             "title": "Battle",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Battle Plans...",
             "socketError": "Error joining battle, refresh and try again.",
             "loading": "Loading Battle Plans...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the battle",
             "warriorRetreated": "{name} has retreated from the battle",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Warrior",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
             "planSkipped": "Plan skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Warrior"
             },
             "battleDeleted": "Battle deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Plans",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Battle",
     "battles": "Battles",
     "battlesActive": "Active Battles",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Battle",
     "battleRemoveSuccess": "Battle removed successfully.",
     "battleRemoveError": "Error attempting to remove battle.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team battles",
     "sessionDuplicate": "Duplicate battle session exists for your ID"
 }

--- a/frontend/public/lang/default/pt.json
+++ b/frontend/public/lang/default/pt.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout warrior",
     "battleDelete": "Delete Battle",
     "battleAbandon": "Abandon Battle",
     "battleCreate": "Create Battle",
     "battleEdit": "Edit Battle",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create Warrior",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Plan",
     "planSkip": "Skip Plan",
     "planName": "Plan Name",
     "planNamePlaceholder": "Enter a plan name",
     "planType": "Plan Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to plan",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import plans from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app with a fun theme",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple {crossoutOpen}User{crossoutClose}Warrior Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Warriors in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Battle Name",
                         "placeholder": "Enter a battle name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Plans",
                         "addButton": "Add Plan",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a plan name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Warriors have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Enlist to Battle",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering warrior as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering warrior as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating warrior",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating warrior"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable battle notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Warriors",
                 "unregistered": "Unregistered Warriors",
@@ -239,55 +68,15 @@
                 "plans": "Plans"
             },
             "registeredWarriors": {
-                "title": "Registered Warriors",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Warriors"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Battles older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Battle",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate warrior",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate warrior"
         },
         "battle": {
             "title": "Battle",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Battle Plans...",
             "socketError": "Error joining battle, refresh and try again.",
             "loading": "Loading Battle Plans...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the battle",
             "warriorRetreated": "{name} has retreated from the battle",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Warrior",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
             "planSkipped": "Plan skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Warrior"
             },
             "battleDeleted": "Battle deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Plans",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Battle",
     "battles": "Battles",
     "battlesActive": "Active Battles",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Battle",
     "battleRemoveSuccess": "Battle removed successfully.",
     "battleRemoveError": "Error attempting to remove battle.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team battles",
     "sessionDuplicate": "Duplicate battle session exists for your ID"
 }

--- a/frontend/public/lang/default/ru.json
+++ b/frontend/public/lang/default/ru.json
@@ -1,62 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Версия {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Выйти",
-    "logoutError": "Ошибка при попытке выйти из профиля",
     "battleDelete": "Удалить битву",
     "battleAbandon": "Покинуть битву",
     "battleCreate": "Создать битву",
     "battleEdit": "Редактировать битву",
-    "battleEditPointsDisabled": "Нельзя менять карточки пока активно голосование.",
-    "save": "Сохранить",
-    "warriorCreate": "Создать участника",
     "warriorNudge": "Напомнить",
     "promote": "Сделать лидером",
-    "demote": "Demote",
-    "planAdd": "Добавить задачу",
-    "planSkip": "Пропустить задачу",
-    "planName": "Заголовок задачи",
-    "planNamePlaceholder": "Введите заголовок задачи",
-    "planType": "Тип задач",
-    "planTypePlaceholder": "Типы задач",
-    "planLink": "Ссылка",
-    "planLinkPlaceholder": "Введите ссылку на задачу",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "ID ссылки",
-    "planReferenceIdPlaceholder": "Введите ID ссылки",
-    "planDescription": "Описание",
-    "planDescriptionPlaceholder": "Введите описание",
-    "planAcceptanceCriteria": "Критерии выполнения",
-    "planAcceptanceCriteriaPlaceholder": "Введите критерии выполнения задачи",
-    "pointed": "Оцененные ({count})",
-    "unpointed": "Неоцененные ({count})",
     "view": "Просмотр",
-    "activate": "Активировать",
-    "votingFinish": "Закончить голосование",
-    "votingRestart": "Перезапустить голосование",
-    "importJiraXML": "Импорт задач из джиры",
-    "importJiraXMLBadFileTypeError": "Ошибка: плохой тип файла",
-    "importJiraXMLReadFileError": "Ошибка чтения файла",
-    "planTypeStory": "история",
-    "planTypeBug": "ошибка",
-    "planTypeSpike": "spike",
-    "planTypeEpic": "эпик",
-    "planTypeTask": "задача",
-    "planTypeSubtask": "подзадача",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app with a fun theme",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple {crossoutOpen}User{crossoutClose}Warrior Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Warriors in over {count} countries",
     "pages": {
         "myBattles": {
             "nav": "Мои битвы",
             "title": "Мои битвы",
             "battlesError": "Ошибка поиска ваших битв",
-            "countPlansPointed": "{totalPointed} из {totalPlans} задач оценено",
             "createBattle": {
                 "title": "Создать битву",
                 "createError": "Ошибка создания битвы",
@@ -64,297 +21,34 @@
                     "name": {
                         "label": "Название битвы",
                         "placeholder": "Введите название битвы"
-                    },
-                    "allowedPointValues": {
-                        "label": "Разрешенные карточки"
-                    },
-                    "plans": {
-                        "label": "Задачи",
-                        "addButton": "Добавить задачу",
-                        "removeButton": "Удалить",
-                        "fields": {
-                            "name": {
-                                "placeholder": "Введите заголовок задачи"
-                            }
-                        }
-                    },
-                    "autoFinishVoting": {
-                        "label": "Автозавершение голосования когда все проголосовали"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Создать профиль",
-            "title": "Войти в битву",
-            "registrationDisabled": "Регистрация отключена.",
-            "guestForm": {
-                "title": "Войти как гость",
-                "saveButton": "Зарегистировать",
-                "createError": "Ошибка регистрации как гостя",
-                "fields": {
-                    "name": {
-                        "label": "Имя",
-                        "placeholder": "Введите имя"
-                    }
-                }
-            },
-            "createAccountForm": {
-                "saveButton": "Создать",
-                "title": "Создать аккаунт {optionalOpen}(Необязательно){optionalClose}",
-                "createError": "Ошибка создания участника",
-                "fields": {
-                    "name": {
-                        "label": "Имя",
-                        "placeholder": "Введите имя"
-                    },
-                    "email": {
-                        "label": "Электронная почта",
-                        "placeholder": "Введите электронную почту"
-                    },
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Повторите пароль"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Подтверждение профиля...",
-            "verified": {
-                "title": "Профиль подтвержден",
-                "thanks": "Спасибо за подтверждение почты."
-            },
-            "failed": {
-                "title": "Верификация завершилась ошибкой",
-                "error": "Произошла ошибка верификации."
-            }
-        },
-        "warriorProfile": {
-            "title": "Профиль",
-            "errorRetreiving": "Ошибка получения профиля",
-            "errorUpdating": "Ошибка обновления профиля",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Пароль обновлен.",
-            "passwordUpdateError": "Ошибка обновления пароля",
-            "updatePasswordButton": "Обновить пароль",
-            "saveProfileButton": "Обновить профиль",
-            "fields": {
-                "name": {
-                    "label": "Имя",
-                    "placeholder": "Введите имя"
-                },
-                "email": {
-                    "label": "Электронная почта",
-                    "verified": "Подтвержден"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Аватар"
-                },
-                "enable_notifications": {
-                    "label": "Включить уведомления"
-                }
-            },
-            "updatePasswordForm": {
-                "title": "Обновить пароль",
-                "cancelButton": "Отмена",
-                "saveButton": "Обновить",
-                "fields": {
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Повторите пароль"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
-            }
+            "title": "Войти в битву"
         },
         "admin": {
-            "nav": "Админка",
-            "title": "Админка",
             "counts": {
-                "registered": "Зарегистрированные участники",
-                "unregistered": "Незарегистрированные",
-                "battles": "Битвы",
-                "plans": "Задачи"
-            },
-            "registeredWarriors": {
-                "title": "Зарегистрированные участники",
-                "name": "Имя",
-                "email": "Электронная почта",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Подтвержден",
-                "rank": "Rank"
+                "battles": "Битвы"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Battles older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Войти",
-            "title": "Войти",
-            "registerForBattle": "or {registerOpen}Войти{registerClose} to join the Battle",
-            "button": "Войти",
-            "authError": "Ошибка при попытке авторизации",
-            "sendResetSuccess": "Инструкция по сбросу отправлена на {email}",
-            "sendResetError": "Ошибка при попытки отправить инструкцию сброса",
-            "fields": {
-                "email": {
-                    "label": "Электронная почта",
-                    "placeholder": "Введите электронную почту"
-                },
-                "password": {
-                    "label": "Пароль",
-                    "placeholder": "Введите пароль",
-                    "forgotLabel": "Забыл пароль"
-                }
-            },
-            "passwordReset": {
-                "title": "Сбросить пароль",
-                "resetError": "Ошибка при попытке сбросить пароль",
-                "saveButton": "Сбросить",
-                "fields": {
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Подтвердить пароль"
-                    }
-                }
-            }
+            "registerForBattle": "or {registerOpen}Войти{registerClose} to join the Battle"
         },
         "battle": {
             "title": "Битва",
-            "warriors": "Участники",
-            "socketReconnecting": "Упс, перезагрузка списка задач...",
-            "socketError": "Ошибка: обновите страницу или попробуйте позже.",
-            "loading": "Загрузка списка задач...",
-            "votingNotStarted": "Голосование еще не началось",
             "warriorJoined": "{name} присоединился к битве",
             "warriorRetreated": "{name} ушел с поля боя",
-            "warriorVoted": "{name} проголосовал",
-            "warriorRetractedVote": "{name} убрал оценку",
-            "warriorNudge": "Хей... {name}, ждем твоего голоса.",
-            "warriorInvite": "Пригласить участника",
             "warriorLeader": "Лидер",
-            "finalPoints": "Итого голосов",
-            "points": "Голоса",
-            "planSkipped": "Задача пропущена",
-            "voteResults": {
-                "totalVotes": "Всего голосов",
-                "average": "Среднее",
-                "highest": "Лучшее",
-                "showVoters": "Показать проголосовавших",
-                "unknownWarrior": "Неизвестный участник"
-            },
             "battleDeleted": "Battle deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Plans",
-    "cancel": "Cancel",
-    "delete": "Удалить",
     "edit": "Изменить",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Battle",
     "battles": "Battles",
     "battlesActive": "Active Battles",
@@ -362,37 +56,6 @@
     "battleJoin": "Join Battle",
     "battleRemoveSuccess": "Battle removed successfully.",
     "battleRemoveError": "Error attempting to remove battle.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team battles",
     "sessionDuplicate": "Duplicate battle session exists for your ID"
 }

--- a/frontend/public/lang/en.json
+++ b/frontend/public/lang/en.json
@@ -1,0 +1,329 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Version {version}",
+    "avatarAltText": "Placeholder Avatar",
+    "logout": "Logout",
+    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
+    "save": "Save",
+    "warriorNudge": "Nudge",
+    "promote": "Promote",
+    "demote": "Demote",
+    "planTypePlaceholder": "Types",
+    "planLink": "Link",
+    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
+    "planReferenceId": "Reference ID",
+    "planReferenceIdPlaceholder": "Enter a reference ID",
+    "planDescription": "Description",
+    "planDescriptionPlaceholder": "Enter a description",
+    "planAcceptanceCriteria": "Acceptance Criteria",
+    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
+    "pointed": "Pointed ({count})",
+    "unpointed": "Unpointed ({count})",
+    "view": "View",
+    "activate": "Activate",
+    "votingFinish": "Finish Voting",
+    "votingRestart": "Restart Voting",
+    "importJiraXMLBadFileTypeError": "Error bad file type",
+    "importJiraXMLReadFileError": "Error reading file",
+    "planTypeStory": "Story",
+    "planTypeBug": "Bug",
+    "planTypeSpike": "Spike",
+    "planTypeEpic": "Epic",
+    "planTypeTask": "Task",
+    "planTypeSubtask": "Subtask",
+    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
+    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
+    "landingBullet3NotSorry": "*sorry, not sorry IE",
+    "landingFeatures": "Features",
+    "landingFeatureOpenSourceTitle": "Open Source",
+    "landingFeatureOpenSourceText": "Check out the {githubIcon}{repoOpen}repository{repoClose} to request or contribute enhancements, locale translations and bug fixes or to {donateOpen}Donate{donateClose}",
+    "pages": {
+        "myBattles": {
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Allowed Point Values"
+                    },
+                    "plans": {
+                        "removeButton": "Remove"
+                    },
+                    "averageRounding": {
+                        "label": "Method of Point Average Rounding",
+                        "ceil": "Ceil",
+                        "floor": "Floor",
+                        "round": "Round"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Create Account",
+            "title": "Enlist to Battle",
+            "registrationDisabled": "Registration is disabled.",
+            "guestForm": {
+                "title": "Register as Guest",
+                "saveButton": "Register",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Create",
+                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
+                "createError": "Error encountered creating warrior",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "placeholder": "Enter your email"
+                    },
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Verifying Account...",
+            "verified": {
+                "title": "Account Verified",
+                "thanks": "Thanks for verifying your email."
+            },
+            "failed": {
+                "title": "Verification Failed",
+                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+            }
+        },
+        "warriorProfile": {
+            "title": "Your Profile",
+            "errorRetreiving": "Error getting your profile",
+            "errorUpdating": "Error encountered updating your profile",
+            "updateSuccess": "Profile updated",
+            "passwordUpdated": "Password updated.",
+            "passwordUpdateError": "Error encountered attempting to update password",
+            "updatePasswordButton": "Update Password",
+            "saveProfileButton": "Update Profile",
+            "fields": {
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Enter your name"
+                },
+                "email": {
+                    "label": "Email",
+                    "verified": "Verified"
+                },
+                "country": {
+                    "label": "Country",
+                    "placeholder": "Choose your country (optional)"
+                },
+                "company": {
+                    "label": "Company",
+                    "placeholder": "Enter your company (optional)"
+                },
+                "jobTitle": {
+                    "label": "Job Title",
+                    "placeholder": "Enter your job title (optional)"
+                },
+                "avatar": {
+                    "label": "Avatar"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Update Password",
+                "cancelButton": "Cancel",
+                "saveButton": "Update",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Keys",
+                "createButton": "Create API Key",
+                "name": "Key Name",
+                "prefix": "Key Prefix",
+                "active": "Active",
+                "updated": "Last Updated",
+                "actions": "Actions",
+                "activateButton": "Activate",
+                "deactivateButton": "Deactivate",
+                "deleteButton": "Delete",
+                "errorRetreiving": "Failed to get API keys",
+                "createFailed": "Failed to create API Key",
+                "deleteFailed": "Failed to delete API Key",
+                "deleteSuccess": "API Key deleted",
+                "updateSuccess": "API Key updated",
+                "updateFailed": "Failed to update API Key",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Enter a Key Name",
+                        "invalid": "Please enter a key name"
+                    },
+                    "submitButton": "Create",
+                    "closeButton": "Close"
+                },
+                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
+                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
+            },
+            "delete": {
+                "deleteButton": "Delete Account",
+                "error": "Error encountered attempting to delete your account.",
+                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
+                "confirmButton": "Confirm Delete",
+                "cancelButton": "Cancel"
+            }
+        },
+        "admin": {
+            "nav": "Admin",
+            "title": "Admin",
+            "registeredWarriors": {
+                "name": "Name",
+                "email": "Email",
+                "country": "Country",
+                "company": "Company",
+                "jobTitle": "Job Title",
+                "verified": "Verified",
+                "rank": "Rank"
+            },
+            "maintenance": {
+                "title": "Maintenance",
+                "cleanGuests": "Clean Guests older than {daysOld} days"
+            }
+        },
+        "login": {
+            "nav": "Login",
+            "title": "Login",
+            "button": "Login",
+            "sendResetSuccess": "Password reset instructions sent to {email}",
+            "sendResetError": "Error encountered attempting to send password reset",
+            "fields": {
+                "email": {
+                    "label": "Email",
+                    "placeholder": "Enter your email"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Enter your password",
+                    "forgotLabel": "Forgot Password?"
+                }
+            },
+            "passwordReset": {
+                "title": "Reset Password",
+                "resetError": "Error encountered attempting to reset password",
+                "saveButton": "Reset",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter your new password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Enter your new password"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "votingNotStarted": "Voting not started",
+            "warriorVoted": "{name} has voted",
+            "warriorRetractedVote": "{name} has retracted vote",
+            "warriorNudge": "pst... {name}, waiting on you to vote.",
+            "warriorLeader": "Leader",
+            "finalPoints": "Final Points",
+            "points": "Points",
+            "voteResults": {
+                "totalVotes": "Total Votes",
+                "average": "Average",
+                "highest": "Highest",
+                "showVoters": "Show Voters"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "Email",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "users": "Users",
+    "type": "Type",
+    "active": "Active",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Updated Date",
+    "dateCreated": "Created Date",
+    "cannotBeUndone": "This cannot be undone.",
+    "userEmail": "User Email",
+    "userEmailPlaceholder": "Enter a registered users email",
+    "userAddSuccess": "User added successfully.",
+    "userAddError": "Error attempting to add user.",
+    "userRemoveSuccess": "User removed successfully.",
+    "userRemoveError": "Error attempting to remove user.",
+    "role": "Role",
+    "rolePlaceholder": "Select users role",
+    "userAdd": "Add User",
+    "flag": "Flag",
+    "alerts": "Alerts",
+    "alertCreate": "Create Alert",
+    "alertNamePlaceholder": "Enter an alert name",
+    "alertTypePlaceholder": "Select an alert type",
+    "alertContent": "Alert Content",
+    "alertContentPlaceholder": "Enter alert content",
+    "alertRegisteredOnly": "Registered Only",
+    "alertAllowDismiss": "Allow Dismiss",
+    "alertSave": "Save Alert",
+    "alertDelete": "Delete Alert",
+    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
+    "department": "Department",
+    "departments": "Departments",
+    "departmentCreate": "Create Department",
+    "departmentName": "Department Name",
+    "departmentNamePlaceholder": "Enter an department name",
+    "departmentSave": "Save Department",
+    "departmentGetError": "Error getting department",
+    "departmentUsersGetError": "Error getting department users",
+    "departmentTeamsGetError": "Error getting department teams",
+    "departmentCreateError": "Error attempting to create department",
+    "organization": "Organization",
+    "organizations": "Organizations",
+    "organizationName": "Organization Name",
+    "organizationNamePlaceholder": "Enter an organization name",
+    "organizationSave": "Save Organization",
+    "organizationGetError": "Error getting organization",
+    "organizationGetDepartmentsError": "Error getting organization departments",
+    "organizationGetTeamsError": "Error getting organization teams",
+    "organizationGetUsersError": "Error getting organization users",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Create Team",
+    "teamCreateSuccess": "Team created successfully.",
+    "teamCreateError": "Error attempting to create team.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter an team name",
+    "teamSave": "Save Team",
+    "teamDeleteSuccess": "Team deleted successfully.",
+    "teamDeleteError": "Error attempting to delete team",
+    "teamGetError": "Error getting team",
+    "teamGetUsersError": "Error getting team users"
+}

--- a/frontend/public/lang/en.json
+++ b/frontend/public/lang/en.json
@@ -331,5 +331,6 @@
     "adminPageAlerts": "Alerts",
     "adminPageOrganizations": "Organizations",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Users"
+    "adminPageUsers": "Users",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/en.json
+++ b/frontend/public/lang/en.json
@@ -266,6 +266,7 @@
     "email": "Email",
     "cancel": "Cancel",
     "delete": "Delete",
+    "remove": "Remove",
     "edit": "Edit",
     "users": "Users",
     "type": "Type",
@@ -325,5 +326,10 @@
     "teamDeleteSuccess": "Team deleted successfully.",
     "teamDeleteError": "Error attempting to delete team",
     "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users"
+    "teamGetUsersError": "Error getting team users",
+    "adminPageAdmin": "Admin",
+    "adminPageAlerts": "Alerts",
+    "adminPageOrganizations": "Organizations",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Users"
 }

--- a/frontend/public/lang/es.json
+++ b/frontend/public/lang/es.json
@@ -1,0 +1,329 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Version {version}",
+    "avatarAltText": "Placeholder Avatar",
+    "logout": "Logout",
+    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
+    "save": "Save",
+    "warriorNudge": "Nudge",
+    "promote": "Promote",
+    "demote": "Demote",
+    "planTypePlaceholder": "Types",
+    "planLink": "Link",
+    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
+    "planReferenceId": "Reference ID",
+    "planReferenceIdPlaceholder": "Enter a reference ID",
+    "planDescription": "Description",
+    "planDescriptionPlaceholder": "Enter a description",
+    "planAcceptanceCriteria": "Acceptance Criteria",
+    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
+    "pointed": "Pointed ({count})",
+    "unpointed": "Unpointed ({count})",
+    "view": "View",
+    "activate": "Activate",
+    "votingFinish": "Finish Voting",
+    "votingRestart": "Restart Voting",
+    "importJiraXMLBadFileTypeError": "Error bad file type",
+    "importJiraXMLReadFileError": "Error reading file",
+    "planTypeStory": "Story",
+    "planTypeBug": "Bug",
+    "planTypeSpike": "Spike",
+    "planTypeEpic": "Epic",
+    "planTypeTask": "Task",
+    "planTypeSubtask": "Subtask",
+    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
+    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
+    "landingBullet3NotSorry": "*sorry, not sorry IE",
+    "landingFeatures": "Features",
+    "landingFeatureOpenSourceTitle": "Open Source",
+    "landingFeatureOpenSourceText": "Check out the {githubIcon}{repoOpen}repository{repoClose} to request or contribute enhancements, locale translations and bug fixes or to {donateOpen}Donate{donateClose}",
+    "pages": {
+        "myBattles": {
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Allowed Point Values"
+                    },
+                    "plans": {
+                        "removeButton": "Remove"
+                    },
+                    "averageRounding": {
+                        "label": "Method of Point Average Rounding",
+                        "ceil": "Ceil",
+                        "floor": "Floor",
+                        "round": "Round"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Create Account",
+            "title": "Enlist to Battle",
+            "registrationDisabled": "Registration is disabled.",
+            "guestForm": {
+                "title": "Register as Guest",
+                "saveButton": "Register",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Create",
+                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
+                "createError": "Error encountered creating warrior",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "placeholder": "Enter your email"
+                    },
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Verifying Account...",
+            "verified": {
+                "title": "Account Verified",
+                "thanks": "Thanks for verifying your email."
+            },
+            "failed": {
+                "title": "Verification Failed",
+                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+            }
+        },
+        "warriorProfile": {
+            "title": "Your Profile",
+            "errorRetreiving": "Error getting your profile",
+            "errorUpdating": "Error encountered updating your profile",
+            "updateSuccess": "Profile updated",
+            "passwordUpdated": "Password updated.",
+            "passwordUpdateError": "Error encountered attempting to update password",
+            "updatePasswordButton": "Update Password",
+            "saveProfileButton": "Update Profile",
+            "fields": {
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Enter your name"
+                },
+                "email": {
+                    "label": "Email",
+                    "verified": "Verified"
+                },
+                "country": {
+                    "label": "Country",
+                    "placeholder": "Choose your country (optional)"
+                },
+                "company": {
+                    "label": "Company",
+                    "placeholder": "Enter your company (optional)"
+                },
+                "jobTitle": {
+                    "label": "Job Title",
+                    "placeholder": "Enter your job title (optional)"
+                },
+                "avatar": {
+                    "label": "Avatar"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Update Password",
+                "cancelButton": "Cancel",
+                "saveButton": "Update",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Keys",
+                "createButton": "Create API Key",
+                "name": "Key Name",
+                "prefix": "Key Prefix",
+                "active": "Active",
+                "updated": "Last Updated",
+                "actions": "Actions",
+                "activateButton": "Activate",
+                "deactivateButton": "Deactivate",
+                "deleteButton": "Delete",
+                "errorRetreiving": "Failed to get API keys",
+                "createFailed": "Failed to create API Key",
+                "deleteFailed": "Failed to delete API Key",
+                "deleteSuccess": "API Key deleted",
+                "updateSuccess": "API Key updated",
+                "updateFailed": "Failed to update API Key",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Enter a Key Name",
+                        "invalid": "Please enter a key name"
+                    },
+                    "submitButton": "Create",
+                    "closeButton": "Close"
+                },
+                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
+                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
+            },
+            "delete": {
+                "deleteButton": "Delete Account",
+                "error": "Error encountered attempting to delete your account.",
+                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
+                "confirmButton": "Confirm Delete",
+                "cancelButton": "Cancel"
+            }
+        },
+        "admin": {
+            "nav": "Admin",
+            "title": "Admin",
+            "registeredWarriors": {
+                "name": "Name",
+                "email": "Email",
+                "country": "Country",
+                "company": "Company",
+                "jobTitle": "Job Title",
+                "verified": "Verified",
+                "rank": "Rank"
+            },
+            "maintenance": {
+                "title": "Maintenance",
+                "cleanGuests": "Clean Guests older than {daysOld} days"
+            }
+        },
+        "login": {
+            "nav": "Login",
+            "title": "Login",
+            "button": "Login",
+            "sendResetSuccess": "Password reset instructions sent to {email}",
+            "sendResetError": "Error encountered attempting to send password reset",
+            "fields": {
+                "email": {
+                    "label": "Email",
+                    "placeholder": "Enter your email"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Enter your password",
+                    "forgotLabel": "Forgot Password?"
+                }
+            },
+            "passwordReset": {
+                "title": "Reset Password",
+                "resetError": "Error encountered attempting to reset password",
+                "saveButton": "Reset",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter your new password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Enter your new password"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "votingNotStarted": "Voting not started",
+            "warriorVoted": "{name} has voted",
+            "warriorRetractedVote": "{name} has retracted vote",
+            "warriorNudge": "pst... {name}, waiting on you to vote.",
+            "warriorLeader": "Leader",
+            "finalPoints": "Final Points",
+            "points": "Points",
+            "voteResults": {
+                "totalVotes": "Total Votes",
+                "average": "Average",
+                "highest": "Highest",
+                "showVoters": "Show Voters"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "Email",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "users": "Users",
+    "type": "Type",
+    "active": "Active",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Updated Date",
+    "dateCreated": "Created Date",
+    "cannotBeUndone": "This cannot be undone.",
+    "userEmail": "User Email",
+    "userEmailPlaceholder": "Enter a registered users email",
+    "userAddSuccess": "User added successfully.",
+    "userAddError": "Error attempting to add user.",
+    "userRemoveSuccess": "User removed successfully.",
+    "userRemoveError": "Error attempting to remove user.",
+    "role": "Role",
+    "rolePlaceholder": "Select users role",
+    "userAdd": "Add User",
+    "flag": "Flag",
+    "alerts": "Alerts",
+    "alertCreate": "Create Alert",
+    "alertNamePlaceholder": "Enter an alert name",
+    "alertTypePlaceholder": "Select an alert type",
+    "alertContent": "Alert Content",
+    "alertContentPlaceholder": "Enter alert content",
+    "alertRegisteredOnly": "Registered Only",
+    "alertAllowDismiss": "Allow Dismiss",
+    "alertSave": "Save Alert",
+    "alertDelete": "Delete Alert",
+    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
+    "department": "Department",
+    "departments": "Departments",
+    "departmentCreate": "Create Department",
+    "departmentName": "Department Name",
+    "departmentNamePlaceholder": "Enter an department name",
+    "departmentSave": "Save Department",
+    "departmentGetError": "Error getting department",
+    "departmentUsersGetError": "Error getting department users",
+    "departmentTeamsGetError": "Error getting department teams",
+    "departmentCreateError": "Error attempting to create department",
+    "organization": "Organization",
+    "organizations": "Organizations",
+    "organizationName": "Organization Name",
+    "organizationNamePlaceholder": "Enter an organization name",
+    "organizationSave": "Save Organization",
+    "organizationGetError": "Error getting organization",
+    "organizationGetDepartmentsError": "Error getting organization departments",
+    "organizationGetTeamsError": "Error getting organization teams",
+    "organizationGetUsersError": "Error getting organization users",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Create Team",
+    "teamCreateSuccess": "Team created successfully.",
+    "teamCreateError": "Error attempting to create team.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter an team name",
+    "teamSave": "Save Team",
+    "teamDeleteSuccess": "Team deleted successfully.",
+    "teamDeleteError": "Error attempting to delete team",
+    "teamGetError": "Error getting team",
+    "teamGetUsersError": "Error getting team users"
+}

--- a/frontend/public/lang/es.json
+++ b/frontend/public/lang/es.json
@@ -331,5 +331,6 @@
     "adminPageAlerts": "Alerts",
     "adminPageOrganizations": "Organizations",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Users"
+    "adminPageUsers": "Users",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/es.json
+++ b/frontend/public/lang/es.json
@@ -266,6 +266,7 @@
     "email": "Email",
     "cancel": "Cancel",
     "delete": "Delete",
+    "remove": "Remove",
     "edit": "Edit",
     "users": "Users",
     "type": "Type",
@@ -325,5 +326,10 @@
     "teamDeleteSuccess": "Team deleted successfully.",
     "teamDeleteError": "Error attempting to delete team",
     "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users"
+    "teamGetUsersError": "Error getting team users",
+    "adminPageAdmin": "Admin",
+    "adminPageAlerts": "Alerts",
+    "adminPageOrganizations": "Organizations",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Users"
 }

--- a/frontend/public/lang/fr.json
+++ b/frontend/public/lang/fr.json
@@ -1,0 +1,329 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Version {version}",
+    "avatarAltText": "Placeholder Avatar",
+    "logout": "Logout",
+    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
+    "save": "Save",
+    "warriorNudge": "Nudge",
+    "promote": "Promote",
+    "demote": "Demote",
+    "planTypePlaceholder": "Types",
+    "planLink": "Link",
+    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
+    "planReferenceId": "Reference ID",
+    "planReferenceIdPlaceholder": "Enter a reference ID",
+    "planDescription": "Description",
+    "planDescriptionPlaceholder": "Enter a description",
+    "planAcceptanceCriteria": "Acceptance Criteria",
+    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
+    "pointed": "Pointed ({count})",
+    "unpointed": "Unpointed ({count})",
+    "view": "View",
+    "activate": "Activate",
+    "votingFinish": "Finish Voting",
+    "votingRestart": "Restart Voting",
+    "importJiraXMLBadFileTypeError": "Error bad file type",
+    "importJiraXMLReadFileError": "Error reading file",
+    "planTypeStory": "Story",
+    "planTypeBug": "Bug",
+    "planTypeSpike": "Spike",
+    "planTypeEpic": "Epic",
+    "planTypeTask": "Task",
+    "planTypeSubtask": "Subtask",
+    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
+    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
+    "landingBullet3NotSorry": "*sorry, not sorry IE",
+    "landingFeatures": "Features",
+    "landingFeatureOpenSourceTitle": "Open Source",
+    "landingFeatureOpenSourceText": "Check out the {githubIcon}{repoOpen}repository{repoClose} to request or contribute enhancements, locale translations and bug fixes or to {donateOpen}Donate{donateClose}",
+    "pages": {
+        "myBattles": {
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Allowed Point Values"
+                    },
+                    "plans": {
+                        "removeButton": "Remove"
+                    },
+                    "averageRounding": {
+                        "label": "Method of Point Average Rounding",
+                        "ceil": "Ceil",
+                        "floor": "Floor",
+                        "round": "Round"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Create Account",
+            "title": "Enlist to Battle",
+            "registrationDisabled": "Registration is disabled.",
+            "guestForm": {
+                "title": "Register as Guest",
+                "saveButton": "Register",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Create",
+                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
+                "createError": "Error encountered creating warrior",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "placeholder": "Enter your email"
+                    },
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Verifying Account...",
+            "verified": {
+                "title": "Account Verified",
+                "thanks": "Thanks for verifying your email."
+            },
+            "failed": {
+                "title": "Verification Failed",
+                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+            }
+        },
+        "warriorProfile": {
+            "title": "Your Profile",
+            "errorRetreiving": "Error getting your profile",
+            "errorUpdating": "Error encountered updating your profile",
+            "updateSuccess": "Profile updated",
+            "passwordUpdated": "Password updated.",
+            "passwordUpdateError": "Error encountered attempting to update password",
+            "updatePasswordButton": "Update Password",
+            "saveProfileButton": "Update Profile",
+            "fields": {
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Enter your name"
+                },
+                "email": {
+                    "label": "Email",
+                    "verified": "Verified"
+                },
+                "country": {
+                    "label": "Country",
+                    "placeholder": "Choose your country (optional)"
+                },
+                "company": {
+                    "label": "Company",
+                    "placeholder": "Enter your company (optional)"
+                },
+                "jobTitle": {
+                    "label": "Job Title",
+                    "placeholder": "Enter your job title (optional)"
+                },
+                "avatar": {
+                    "label": "Avatar"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Update Password",
+                "cancelButton": "Cancel",
+                "saveButton": "Update",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Keys",
+                "createButton": "Create API Key",
+                "name": "Key Name",
+                "prefix": "Key Prefix",
+                "active": "Active",
+                "updated": "Last Updated",
+                "actions": "Actions",
+                "activateButton": "Activate",
+                "deactivateButton": "Deactivate",
+                "deleteButton": "Delete",
+                "errorRetreiving": "Failed to get API keys",
+                "createFailed": "Failed to create API Key",
+                "deleteFailed": "Failed to delete API Key",
+                "deleteSuccess": "API Key deleted",
+                "updateSuccess": "API Key updated",
+                "updateFailed": "Failed to update API Key",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Enter a Key Name",
+                        "invalid": "Please enter a key name"
+                    },
+                    "submitButton": "Create",
+                    "closeButton": "Close"
+                },
+                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
+                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
+            },
+            "delete": {
+                "deleteButton": "Delete Account",
+                "error": "Error encountered attempting to delete your account.",
+                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
+                "confirmButton": "Confirm Delete",
+                "cancelButton": "Cancel"
+            }
+        },
+        "admin": {
+            "nav": "Admin",
+            "title": "Admin",
+            "registeredWarriors": {
+                "name": "Name",
+                "email": "Email",
+                "country": "Country",
+                "company": "Company",
+                "jobTitle": "Job Title",
+                "verified": "Verified",
+                "rank": "Rank"
+            },
+            "maintenance": {
+                "title": "Maintenance",
+                "cleanGuests": "Clean Guests older than {daysOld} days"
+            }
+        },
+        "login": {
+            "nav": "Login",
+            "title": "Login",
+            "button": "Login",
+            "sendResetSuccess": "Password reset instructions sent to {email}",
+            "sendResetError": "Error encountered attempting to send password reset",
+            "fields": {
+                "email": {
+                    "label": "Email",
+                    "placeholder": "Enter your email"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Enter your password",
+                    "forgotLabel": "Forgot Password?"
+                }
+            },
+            "passwordReset": {
+                "title": "Reset Password",
+                "resetError": "Error encountered attempting to reset password",
+                "saveButton": "Reset",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter your new password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Enter your new password"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "votingNotStarted": "Voting not started",
+            "warriorVoted": "{name} has voted",
+            "warriorRetractedVote": "{name} has retracted vote",
+            "warriorNudge": "pst... {name}, waiting on you to vote.",
+            "warriorLeader": "Leader",
+            "finalPoints": "Final Points",
+            "points": "Points",
+            "voteResults": {
+                "totalVotes": "Total Votes",
+                "average": "Average",
+                "highest": "Highest",
+                "showVoters": "Show Voters"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "Email",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "users": "Users",
+    "type": "Type",
+    "active": "Active",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Updated Date",
+    "dateCreated": "Created Date",
+    "cannotBeUndone": "This cannot be undone.",
+    "userEmail": "User Email",
+    "userEmailPlaceholder": "Enter a registered users email",
+    "userAddSuccess": "User added successfully.",
+    "userAddError": "Error attempting to add user.",
+    "userRemoveSuccess": "User removed successfully.",
+    "userRemoveError": "Error attempting to remove user.",
+    "role": "Role",
+    "rolePlaceholder": "Select users role",
+    "userAdd": "Add User",
+    "flag": "Flag",
+    "alerts": "Alerts",
+    "alertCreate": "Create Alert",
+    "alertNamePlaceholder": "Enter an alert name",
+    "alertTypePlaceholder": "Select an alert type",
+    "alertContent": "Alert Content",
+    "alertContentPlaceholder": "Enter alert content",
+    "alertRegisteredOnly": "Registered Only",
+    "alertAllowDismiss": "Allow Dismiss",
+    "alertSave": "Save Alert",
+    "alertDelete": "Delete Alert",
+    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
+    "department": "Department",
+    "departments": "Departments",
+    "departmentCreate": "Create Department",
+    "departmentName": "Department Name",
+    "departmentNamePlaceholder": "Enter an department name",
+    "departmentSave": "Save Department",
+    "departmentGetError": "Error getting department",
+    "departmentUsersGetError": "Error getting department users",
+    "departmentTeamsGetError": "Error getting department teams",
+    "departmentCreateError": "Error attempting to create department",
+    "organization": "Organization",
+    "organizations": "Organizations",
+    "organizationName": "Organization Name",
+    "organizationNamePlaceholder": "Enter an organization name",
+    "organizationSave": "Save Organization",
+    "organizationGetError": "Error getting organization",
+    "organizationGetDepartmentsError": "Error getting organization departments",
+    "organizationGetTeamsError": "Error getting organization teams",
+    "organizationGetUsersError": "Error getting organization users",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Create Team",
+    "teamCreateSuccess": "Team created successfully.",
+    "teamCreateError": "Error attempting to create team.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter an team name",
+    "teamSave": "Save Team",
+    "teamDeleteSuccess": "Team deleted successfully.",
+    "teamDeleteError": "Error attempting to delete team",
+    "teamGetError": "Error getting team",
+    "teamGetUsersError": "Error getting team users"
+}

--- a/frontend/public/lang/fr.json
+++ b/frontend/public/lang/fr.json
@@ -331,5 +331,6 @@
     "adminPageAlerts": "Alerts",
     "adminPageOrganizations": "Organizations",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Users"
+    "adminPageUsers": "Users",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/fr.json
+++ b/frontend/public/lang/fr.json
@@ -266,6 +266,7 @@
     "email": "Email",
     "cancel": "Cancel",
     "delete": "Delete",
+    "remove": "Remove",
     "edit": "Edit",
     "users": "Users",
     "type": "Type",
@@ -325,5 +326,10 @@
     "teamDeleteSuccess": "Team deleted successfully.",
     "teamDeleteError": "Error attempting to delete team",
     "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users"
+    "teamGetUsersError": "Error getting team users",
+    "adminPageAdmin": "Admin",
+    "adminPageAlerts": "Alerts",
+    "adminPageOrganizations": "Organizations",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Users"
 }

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -6,7 +6,6 @@
     "battleEdit": "Partie bearbeiten",
     "warriorCreate": "Benutzer erstellen",
     "landingBullet2": "Einfache Benutzer-Erfahrung",
-    "landingBullet3": "Funktioniert mit allen {mbOpen}modernen Browsers*{mbClose}, inklusive Mobile",
     "landingCountries": "Benutzer in \u00FCber {count} L\u00E4ndern",
     "pages": {
         "myBattles": {

--- a/frontend/public/lang/friendly/de.json
+++ b/frontend/public/lang/friendly/de.json
@@ -1,62 +1,18 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Avatar Platzhalter",
-    "logout": "Abmelden",
     "logoutError": "Fehler beim Abmelden des Benutzers",
     "battleDelete": "Partie l\u00F6schen",
     "battleAbandon": "Partie verlassen",
     "battleCreate": "Partie erstellen",
     "battleEdit": "Partie bearbeiten",
-    "battleEditPointsDisabled": "Sch\u00E4tzung ist aktiv, zul\u00E4ssige Punkte k\u00F6nnen nicht ge\u00E4ndert werden.",
-    "save": "Speichern",
     "warriorCreate": "Benutzer erstellen",
-    "warriorNudge": "Anstubsen",
-    "promote": "Bef\u00F6rdern",
-    "demote": "Degradieren",
-    "planAdd": "Plan hinzuf\u00FCgen",
-    "planSkip": "Plan \u00FCberspringen",
-    "planName": "Story Name",
-    "planNamePlaceholder": "Plan Name eingeben",
-    "planType": "Plan Typ",
-    "planTypePlaceholder": "Typen",
-    "planLink": "Link",
-    "planLinkPlaceholder": "Link zum Plan eingeben",
-    "planLinkInvalid": "Der Link ist keine g\u00FCltige absolute URL, ent\u00E4lt z.B. das Protokol (HTTP/HTTPS)",
-    "planReferenceId": "Referenz ID",
-    "planReferenceIdPlaceholder": "Referenz ID eingeben",
-    "planDescription": "Beschreibung",
-    "planDescriptionPlaceholder": "Beschreibung eingeben",
-    "planAcceptanceCriteria": "Akzeptanzkriterien",
-    "planAcceptanceCriteriaPlaceholder": "Akzeptanzkriterien eingeben",
-    "pointed": "Gesch\u00E4tzt ({count})",
-    "unpointed": "Ungesch\u00E4tzt ({count})",
-    "view": "Anzeigen",
-    "activate": "Aktivieren",
-    "votingFinish": "Sch\u00E4tzung beenden",
-    "votingRestart": "Sch\u00E4tzung neu starten",
-    "importJiraXML": "Jira XML Import",
-    "importJiraXMLBadFileTypeError": "Fehler: falscher Datei-Typ",
-    "importJiraXMLReadFileError": "Fehler beim Lesen der Datei",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
-    "landingTitle": "Thunderdome ist eine Open Source Agile Planning Poker App mit einem lustigen Thema",
-    "landingBullet1": "Gebaut mit coolen Technologien wie Svelte, Go und WebSockets",
     "landingBullet2": "Einfache Benutzer-Erfahrung",
     "landingBullet3": "Funktioniert mit allen {mbOpen}modernen Browsers*{mbClose}, inklusive Mobile",
-    "landingBullet3NotSorry": "*Entschuldigung, keine Entschuldigung bei IE",
-    "landingFeatures": "Eigenschaften",
     "landingCountries": "Benutzer in \u00FCber {count} L\u00E4ndern",
     "pages": {
         "myBattles": {
             "nav": "Meine Partien",
             "title": "Meine Partien",
             "battlesError": "Fehler: Keine Partie gefunden",
-            "countPlansPointed": "{totalPointed} von {totalPlans} Pl\u00E4nen gesch\u00E4tzt",
             "createBattle": {
                 "title": "Partie erstellen",
                 "createError": "Fehler beim Erstellen einer Partie",
@@ -65,229 +21,37 @@
                         "label": "Name der Partie",
                         "placeholder": "Name der Partie eingeben"
                     },
-                    "allowedPointValues": {
-                        "label": "Zul\u00E4ssige Sch\u00E4tzwerte"
-                    },
-                    "plans": {
-                        "label": "Pl\u00E4ne",
-                        "addButton": "Hinzuf\u00FCgen",
-                        "removeButton": "Entfernen",
-                        "fields": {
-                            "name": {
-                                "placeholder": "Name f\u00FCr den Plan eingeben"
-                            }
-                        }
-                    },
                     "autoFinishVoting": {
                         "label": "Sch\u00E4tzung automatisch beenden, wenn alle Benutzer gesch\u00E4tzt haben"
-                    },
-                    "averageRounding": {
-                        "label": "Methode zur Rundung des Punkteschnitts",
-                        "ceil": "Aufrunden",
-                        "floor": "Abrunden",
-                        "round": "Kaufm. Runden"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Konto erstellen",
             "title": "Der Partie beitreten",
-            "registrationDisabled": "Registrierung ist deaktiviert.",
             "guestForm": {
-                "title": "Als Gast teilnehmen",
-                "saveButton": "Teilnehmen",
-                "createError": "Beim Registrieren als Gast-Benutzer ist ein Fehler aufgetreten",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Name eingeben"
-                    }
-                }
+                "createError": "Beim Registrieren als Gast-Benutzer ist ein Fehler aufgetreten"
             },
             "createAccountForm": {
-                "saveButton": "Erstellen",
-                "title": "Konto erstellen {optionalOpen}(optional){optionalClose}",
-                "createError": "Beim Erstellen des Benutzers ist ein Fehler aufgetreten",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Name eingeben"
-                    },
-                    "email": {
-                        "label": "E-Mail",
-                        "placeholder": "E-Mail eingeben"
-                    },
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort best\u00E4tigen"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Konto\u00FCberpr\u00FCfung...",
-            "verified": {
-                "title": "Konto \u00FCberpr\u00FCft",
-                "thanks": "Vielen Dank f\u00FCr die Best\u00E4tigung der E-Mail-Adresse."
-            },
-            "failed": {
-                "title": "\u00DCberpr\u00FCfung fehlgeschlagen",
-                "error": "Bei der \u00DCberpr\u00FCfung des Kontos ist ein Fehler aufgetreten. M\u00F6glicherweise ist dieser Link abgelaufen oder wurde bereits verwendet."
-            }
-        },
-        "warriorProfile": {
-            "title": "Profil",
-            "errorRetreiving": "Beim Laden des Profils ist ein Fehler aufgetreten",
-            "errorUpdating": "Beim Aktualisieren des Profils ist ein Fehler aufgetreten",
-            "updateSuccess": "Profil aktualisiert",
-            "passwordUpdated": "Passwort aktualisiert",
-            "passwordUpdateError": "Beim Versuch, das Kennwort zu aktualisieren, ist ein Fehler aufgetreten",
-            "updatePasswordButton": "Passwort \u00E4ndern",
-            "saveProfileButton": "Profil aktualisieren",
-            "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Name eingeben"
-                },
-                "email": {
-                    "label": "E-Mail",
-                    "verified": "Best\u00E4tigt"
-                },
-                "country": {
-                    "label": "Land",
-                    "placeholder": "Land w\u00E4hlen (optional)"
-                },
-                "company": {
-                    "label": "Firma",
-                    "placeholder": "Firma eingeben (optional)"
-                },
-                "jobTitle": {
-                    "label": "Berufsbezeichnung",
-                    "placeholder": "Berufsbezeichnung eingeben (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
-                "enable_notifications": {
-                    "label": "Benachrichtigungen aktivieren"
-                }
-            },
-            "updatePasswordForm": {
-                "title": "Passwort \u00E4ndern",
-                "cancelButton": "Abbruch",
-                "saveButton": "Speichern",
-                "fields": {
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort best\u00E4tigen"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Key",
-                "createButton": "API Key erstellen",
-                "name": "Key Name",
-                "prefix": "Key Pr\u00E4fix",
-                "active": "Aktiv",
-                "updated": "Zuletzt aktualisiert",
-                "actions": "Aktionen",
-                "activateButton": "Aktivieren",
-                "deactivateButton": "Deaktivieren",
-                "deleteButton": "L\u00F6schen",
-                "errorRetreiving": "API keys konnten nicht abgerufen werden ",
-                "createFailed": "API Key konnte nicht erstellt werden",
-                "deleteFailed": "API Key konnte nicht gel\u00F6scht werden",
-                "deleteSuccess": "API Key gel\u00F6scht",
-                "updateSuccess": "API Key aktualisiert",
-                "updateFailed": "API Key konnte nicht aktualisiert werden",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Key Name eingeben",
-                        "invalid": "Bitte einen Key Namen angeben"
-                    },
-                    "submitButton": "Erstellen",
-                    "closeButton": "Schlie\u00dfen"
-                },
-                "createSuccess": "Neuer Api Key {keyName} erstellt und {onlyNowOpen}dieser wird nur jetzt angezeigt{onlyNowClose}",
-                "storeWarning": "Bitte den Api Key an einem sicheren Ort aufbewahren, da dieses generierte Token nicht mehr abgerufen oder wiederhergestellt werden kann, sobald diese Seite verlassen wurde."
-            },
-            "delete": {
-                "deleteButton": "Konto l\u00F6schen",
-                "error": "Es ist ein Fehler beim L\u00F6schen des Kontos aufgetreten.",
-                "warningStatement": "Konto wirklich l\u00F6schen? Dies kann nicht R\u00FCckg\u00E4ngig gemacht werden.",
-                "confirmButton": "L\u00F6schen best\u00E4tigen",
-                "cancelButton": "Abbruch"
+                "createError": "Beim Erstellen des Benutzers ist ein Fehler aufgetreten"
             }
         },
         "admin": {
-            "nav": "Verwaltung",
-            "title": "Verwaltung",
             "counts": {
                 "registered": "Registrierte Benutzer",
                 "unregistered": "Nicht registrierte Benutzer",
-                "battles": "Partien",
-                "plans": "Pl\u00E4ne"
+                "battles": "Partien"
             },
             "registeredWarriors": {
-                "title": "Registrierte Benutzer",
-                "name": "Name",
-                "email": "E-Mail",
-                "country": "Land",
-                "company": "Firma",
-                "jobTitle": "Berufsbezeichnung",
-                "verified": "Best\u00E4tigt",
-                "rank": "Rang"
+                "title": "Registrierte Benutzer"
             },
             "maintenance": {
-                "title": "Wartung",
-                "cleanGuests": "Entferne G\u00E4ste \u00E4lter als {daysOld} Tage",
                 "cleanBattles": "Entferne Partien \u00E4lter als {daysOld} Tage"
             }
         },
         "login": {
-            "nav": "Anmeldung",
-            "title": "Anmeldung",
             "registerForBattle": "oder {registerOpen}Anmeldung{registerClose}, um der Partie beizutreten",
-            "button": "Anmelden",
-            "authError": "Beim Versuch, den Benutzer zu authentifizieren, ist ein Fehler aufgetreten",
-            "sendResetSuccess": "Anweisungen zum Zur\u00FCcksetzen des Passworts wurden an {email} gesendet",
-            "sendResetError": "Beim Senden der E-Mail zum Zur\u00FCcksetzen ist ein Fehler aufgetreten",
-            "fields": {
-                "email": {
-                    "label": "E-Mail",
-                    "placeholder": "E-Mail eingeben"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Passwort eingeben",
-                    "forgotLabel": "Passwort vergessen?"
-                }
-            },
-            "passwordReset": {
-                "title": "Passwort zur\u00FCcksetzen",
-                "resetError": "Fehler beim Versuch, das Passwort zur\u00FCckzusetzen",
-                "saveButton": "Zur\u00FCcksetzen",
-                "fields": {
-                    "password": {
-                        "label": "Passwort",
-                        "placeholder": "Passwort eingeben"
-                    },
-                    "confirmPassword": {
-                        "label": "Passwort best\u00E4tigen",
-                        "placeholder": "Passwort eingeben"
-                    }
-                }
-            }
+            "authError": "Beim Versuch, den Benutzer zu authentifizieren, ist ein Fehler aufgetreten"
         },
         "battle": {
             "title": "Partie",
@@ -295,66 +59,15 @@
             "socketReconnecting": "Ooops, Partien werden neu geladen...",
             "socketError": "Fehler beim Eintritt in die Partie, bitte aktualisieren und nochmals versuchen.",
             "loading": "Lade Partien...",
-            "votingNotStarted": "Sch\u00E4tzung noch nicht gestartet",
             "warriorJoined": "{name} hat die Partie betreten",
             "warriorRetreated": "{name} hat die Partie verlassen",
-            "warriorVoted": "{name} hat eine Sch\u00E4tzung abegeben",
-            "warriorRetractedVote": "{name} hat die Sch\u00E4tzung zur\u00FCckgezogen",
-            "warriorNudge": "pst... {name}, wir warten auf eine Sch\u00E4tzung",
             "warriorInvite": "Benutzer einladen",
-            "warriorLeader": "Chef",
-            "finalPoints": "Finale Punkte",
-            "points": "Punkte",
-            "planSkipped": "Plan \u00FCbersprungen",
             "voteResults": {
-                "totalVotes": "Sch\u00E4tzungen",
-                "average": "Durchschnitt",
-                "highest": "H\u00F6chster",
-                "showVoters": "Zeige Sch\u00E4tzer",
                 "unknownWarrior": "Unbekannter Benutzer"
             },
             "battleDeleted": "Partie gel\u00F6scht"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "Der Source Code ist lizensiert {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Erstellt mit {svelteOpen}Svelte{svelteClose} und {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "E-Mail",
-    "plans": "Pl\u00E4ne",
-    "cancel": "Abbruch",
-    "delete": "L\u00F6schen",
-    "edit": "Bearbeiten",
-    "users": "Benutzer",
-    "type": "Typ",
-    "active": "Aktiv",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Aktualisierungsdatum",
-    "dateCreated": "Erstellungsdatum",
-    "cannotBeUndone": "Das kann nicht r\u00FCckg\u00E4ngig gemacht werden.",
-    "userEmail": "Benutzer E-Mail",
-    "userEmailPlaceholder": "E-Mail-Adresse eines registrierten Benutzers eingeben",
-    "userAddSuccess": "Benutzer erfolgreich hinzugef\u00FCgt.",
-    "userAddError": "Fehler beim Versuch, den Benutzer anzulegen.",
-    "userRemoveSuccess": "Benutzer erfolgreich entfernt.",
-    "userRemoveError": "Fehler beim Versuch, den Benutzer zu entfernen.",
-    "role": "Rolle",
-    "rolePlaceholder": "Benutzerrolle ausw\u00E4hlen",
-    "userAdd": "Benutzer hinzuf\u00FCgen",
-    "flag": "Flag",
-    "alerts": "Benachrichtigungen",
-    "alertCreate": "Benachrichtigung erstellen",
-    "alertNamePlaceholder": "Name f\u00FCr die Benachrichtigung eingeben",
-    "alertTypePlaceholder": "Benachrichtigungstyp ausw\u00E4hlen",
-    "alertContent": "Benachrichtigungsinhalt",
-    "alertContentPlaceholder": "Benachrichtigungsinhalt eingeben",
-    "alertRegisteredOnly": "Nur registrierte",
-    "alertAllowDismiss": "Ablehnen zulassen",
-    "alertSave": "Benachrichtigung speichern",
-    "alertDelete": "Benachrichtigung l\u00F6schen",
-    "alertDeleteConfirmation": "Diese Benachrichtigung wirklich l\u00F6schen?",
     "battle": "Partie",
     "battles": "Partien",
     "battlesActive": "Aktive Partien",
@@ -362,37 +75,6 @@
     "battleJoin": "Partie beitreten",
     "battleRemoveSuccess": "Partie erfolgreich entfernt.",
     "battleRemoveError": "Fehler beim Entfernen der Partie aufgetreten.",
-    "department": "Abteilung",
-    "departments": "Abteilungen",
-    "departmentCreate": "Abteilung anlegen",
-    "departmentName": "Abteilungsname",
-    "departmentNamePlaceholder": "Abteilungsname angeben",
-    "departmentSave": "Abteilung speichern",
-    "departmentGetError": "Fehler beim Ermitteln der Abteilung",
-    "departmentUsersGetError": "Fehler beim Ermitteln der Benutzer der Abteilung",
-    "departmentTeamsGetError": "Fehler beim Ermitteln der Teams der Abteilung",
-    "departmentCreateError": "Fehler beim Erstellen der Abteilung",
-    "organization": "Unternehmen",
-    "organizations": "Unternehmen",
-    "organizationName": "Unternehmensname",
-    "organizationNamePlaceholder": "Unternehmensname angeben",
-    "organizationSave": "Unternehmen speichern",
-    "organizationGetError": "Fehler beim Ermitteln des Unternehmens",
-    "organizationGetDepartmentsError": "Fehler beim Ermitteln der Unternehmens-Abteilungen",
-    "organizationGetTeamsError": "Fehler beim Ermitteln der Teams des Unternehmens",
-    "organizationGetUsersError": "Fehler beim Ermitteln der Benutzer des Unternehmens",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Team erstellen",
-    "teamCreateSuccess": "Team erfolgreich angelegt.",
-    "teamCreateError": "Fehler beim Erstellen des Teams.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Team Name angeben",
-    "teamSave": "Team speichern",
-    "teamDeleteSuccess": "Team erfolgreich gel\u00F6scht",
-    "teamDeleteError": "Fehler beim L\u00F6schen des Teams",
-    "teamGetError": "Fehler beim Ermitteln des Teams",
-    "teamGetUsersError": "Fehler beim Ermitteln der Benutzer des Teams",
-    "teamGetBattlesError": "Fehler beim Ermitteln der Schlachten des Teams",
-    "sessionDuplicate": "Es existiert bereits eine Schlacht-Sitzung f\u00FCr Ihre ID"
+    "teamGetBattlesError": "Fehler beim Ermitteln der Partien des Teams",
+    "sessionDuplicate": "Es existiert bereits eine Partie-Sitzung f\u00FCr Ihre ID"
 }

--- a/frontend/public/lang/friendly/en.json
+++ b/frontend/public/lang/friendly/en.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout user",
     "battleDelete": "Delete Game",
     "battleAbandon": "Abandon Game",
     "battleCreate": "Create Game",
     "battleEdit": "Edit Game",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create User",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Story",
     "planSkip": "Skip Story",
     "planName": "Story Name",
     "planNamePlaceholder": "Enter a story name",
     "planType": "Story Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to story",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import stories from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple Player Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Users in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Game Name",
                         "placeholder": "Enter a game name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Stories",
                         "addButton": "Add Story",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a story name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Players have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Register to join pointing games",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering player as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering player as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating player",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating player"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable game notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Players",
                 "unregistered": "Unregistered Players",
@@ -239,55 +68,15 @@
                 "plans": "Stories"
             },
             "registeredWarriors": {
-                "title": "Registered Players",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Players"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Games older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Game",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate player",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate player"
         },
         "battle": {
             "title": "Game",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Game...",
             "socketError": "Error joining game, refresh and try again.",
             "loading": "Loading Game...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the game",
             "warriorRetreated": "{name} has left the game",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Player",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
-            "planSkipped": "Plan skipped",
+            "planSkipped": "Story skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Player"
             },
             "battleDeleted": "Game deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Stories",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Game",
     "battles": "Games",
     "battlesActive": "Active Games",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Game",
     "battleRemoveSuccess": "Game removed successfully.",
     "battleRemoveError": "Error attempting to remove game.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team games",
     "sessionDuplicate": "Duplicate game session exists for your ID"
 }

--- a/frontend/public/lang/friendly/es.json
+++ b/frontend/public/lang/friendly/es.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout user",
     "battleDelete": "Delete Game",
     "battleAbandon": "Abandon Game",
     "battleCreate": "Create Game",
     "battleEdit": "Edit Game",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create User",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Story",
     "planSkip": "Skip Story",
     "planName": "Story Name",
     "planNamePlaceholder": "Enter a story name",
     "planType": "Story Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to story",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import stories from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple Player Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Users in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Game Name",
                         "placeholder": "Enter a game name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Stories",
                         "addButton": "Add Story",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a story name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Players have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Register to join pointing games",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering player as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering player as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating player",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating player"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable game notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Players",
                 "unregistered": "Unregistered Players",
@@ -239,55 +68,15 @@
                 "plans": "Stories"
             },
             "registeredWarriors": {
-                "title": "Registered Players",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Players"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Games older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Game",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate player",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate player"
         },
         "battle": {
             "title": "Game",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Game...",
             "socketError": "Error joining game, refresh and try again.",
             "loading": "Loading Game...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the game",
             "warriorRetreated": "{name} has left the game",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Player",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
-            "planSkipped": "Plan skipped",
+            "planSkipped": "Story skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Player"
             },
             "battleDeleted": "Game deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Stories",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Game",
     "battles": "Games",
     "battlesActive": "Active Games",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Game",
     "battleRemoveSuccess": "Game removed successfully.",
     "battleRemoveError": "Error attempting to remove game.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team games",
     "sessionDuplicate": "Duplicate game session exists for your ID"
 }

--- a/frontend/public/lang/friendly/fr.json
+++ b/frontend/public/lang/friendly/fr.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout user",
     "battleDelete": "Delete Game",
     "battleAbandon": "Abandon Game",
     "battleCreate": "Create Game",
     "battleEdit": "Edit Game",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create User",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Story",
     "planSkip": "Skip Story",
     "planName": "Story Name",
     "planNamePlaceholder": "Enter a story name",
     "planType": "Story Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to story",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import stories from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple Player Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Users in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Game Name",
                         "placeholder": "Enter a game name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Stories",
                         "addButton": "Add Story",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a story name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Players have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Register to join pointing games",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering player as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering player as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating player",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating player"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable game notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Players",
                 "unregistered": "Unregistered Players",
@@ -239,55 +68,15 @@
                 "plans": "Stories"
             },
             "registeredWarriors": {
-                "title": "Registered Players",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Players"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Games older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Game",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate player",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate player"
         },
         "battle": {
             "title": "Game",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Game...",
             "socketError": "Error joining game, refresh and try again.",
             "loading": "Loading Game...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the game",
             "warriorRetreated": "{name} has left the game",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Player",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
-            "planSkipped": "Plan skipped",
+            "planSkipped": "Story skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Player"
             },
             "battleDeleted": "Game deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Stories",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Game",
     "battles": "Games",
     "battlesActive": "Active Games",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Game",
     "battleRemoveSuccess": "Game removed successfully.",
     "battleRemoveError": "Error attempting to remove game.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team games",
     "sessionDuplicate": "Duplicate game session exists for your ID"
 }

--- a/frontend/public/lang/friendly/pt.json
+++ b/frontend/public/lang/friendly/pt.json
@@ -1,55 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Version {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Logout",
     "logoutError": "Error encountered attempting to logout user",
     "battleDelete": "Delete Game",
     "battleAbandon": "Abandon Game",
     "battleCreate": "Create Game",
     "battleEdit": "Edit Game",
-    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
-    "save": "Save",
     "warriorCreate": "Create User",
-    "warriorNudge": "Nudge",
-    "promote": "Promote",
-    "demote": "Demote",
     "planAdd": "Add Story",
     "planSkip": "Skip Story",
     "planName": "Story Name",
     "planNamePlaceholder": "Enter a story name",
     "planType": "Story Type",
-    "planTypePlaceholder": "Types",
-    "planLink": "Link",
     "planLinkPlaceholder": "Enter a link to story",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "Reference ID",
-    "planReferenceIdPlaceholder": "Enter a reference ID",
-    "planDescription": "Description",
-    "planDescriptionPlaceholder": "Enter a description",
-    "planAcceptanceCriteria": "Acceptance Criteria",
-    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
-    "pointed": "Pointed ({count})",
-    "unpointed": "Unpointed ({count})",
-    "view": "View",
-    "activate": "Activate",
-    "votingFinish": "Finish Voting",
-    "votingRestart": "Restart Voting",
     "importJiraXML": "Import stories from Jira XML",
-    "importJiraXMLBadFileTypeError": "Error bad file type",
-    "importJiraXMLReadFileError": "Error reading file",
-    "planTypeStory": "Story",
-    "planTypeBug": "Bug",
-    "planTypeSpike": "Spike",
-    "planTypeEpic": "Epic",
-    "planTypeTask": "Task",
-    "planTypeSubtask": "Subtask",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple Player Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Users in over {count} countries",
     "pages": {
         "myBattles": {
@@ -65,13 +29,9 @@
                         "label": "Game Name",
                         "placeholder": "Enter a game name"
                     },
-                    "allowedPointValues": {
-                        "label": "Allowed Point Values"
-                    },
                     "plans": {
                         "label": "Stories",
                         "addButton": "Add Story",
-                        "removeButton": "Remove",
                         "fields": {
                             "name": {
                                 "placeholder": "Enter a story name"
@@ -80,158 +40,27 @@
                     },
                     "autoFinishVoting": {
                         "label": "Auto Finish Voting when all Players have voted"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Create Account",
             "title": "Register to join pointing games",
-            "registrationDisabled": "Registration is disabled.",
             "guestForm": {
-                "title": "Register as Guest",
-                "saveButton": "Register",
-                "createError": "Error encountered registering player as guest",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    }
-                }
+                "createError": "Error encountered registering player as guest"
             },
             "createAccountForm": {
-                "saveButton": "Create",
-                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
-                "createError": "Error encountered creating player",
-                "fields": {
-                    "name": {
-                        "label": "Name",
-                        "placeholder": "Enter your name"
-                    },
-                    "email": {
-                        "label": "Email",
-                        "placeholder": "Enter your email"
-                    },
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Verifying Account...",
-            "verified": {
-                "title": "Account Verified",
-                "thanks": "Thanks for verifying your email."
-            },
-            "failed": {
-                "title": "Verification Failed",
-                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+                "createError": "Error encountered creating player"
             }
         },
         "warriorProfile": {
-            "title": "Your Profile",
-            "errorRetreiving": "Error getting your profile",
-            "errorUpdating": "Error encountered updating your profile",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Password updated.",
-            "passwordUpdateError": "Error encountered attempting to update password",
-            "updatePasswordButton": "Update Password",
-            "saveProfileButton": "Update Profile",
             "fields": {
-                "name": {
-                    "label": "Name",
-                    "placeholder": "Enter your name"
-                },
-                "email": {
-                    "label": "Email",
-                    "verified": "Verified"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Avatar"
-                },
                 "enable_notifications": {
                     "label": "Enable game notifications"
                 }
-            },
-            "updatePasswordForm": {
-                "title": "Update Password",
-                "cancelButton": "Cancel",
-                "saveButton": "Update",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter a password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Confirm your password"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
             }
         },
         "admin": {
-            "nav": "Admin",
-            "title": "Admin",
             "counts": {
                 "registered": "Registered Players",
                 "unregistered": "Unregistered Players",
@@ -239,55 +68,15 @@
                 "plans": "Stories"
             },
             "registeredWarriors": {
-                "title": "Registered Players",
-                "name": "Name",
-                "email": "Email",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Verified",
-                "rank": "Rank"
+                "title": "Registered Players"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Games older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Login",
-            "title": "Login",
             "registerForBattle": "or {registerOpen}Register{registerClose} to join the Game",
-            "button": "Login",
-            "authError": "Error encountered attempting to authenticate player",
-            "sendResetSuccess": "Password reset instructions sent to {email}",
-            "sendResetError": "Error encountered attempting to send password reset",
-            "fields": {
-                "email": {
-                    "label": "Email",
-                    "placeholder": "Enter your email"
-                },
-                "password": {
-                    "label": "Password",
-                    "placeholder": "Enter your password",
-                    "forgotLabel": "Forgot Password?"
-                }
-            },
-            "passwordReset": {
-                "title": "Reset Password",
-                "resetError": "Error encountered attempting to reset password",
-                "saveButton": "Reset",
-                "fields": {
-                    "password": {
-                        "label": "Password",
-                        "placeholder": "Enter your new password"
-                    },
-                    "confirmPassword": {
-                        "label": "Confirm Password",
-                        "placeholder": "Enter your new password"
-                    }
-                }
-            }
+            "authError": "Error encountered attempting to authenticate player"
         },
         "battle": {
             "title": "Game",
@@ -295,66 +84,17 @@
             "socketReconnecting": "Ooops, reloading Game...",
             "socketError": "Error joining game, refresh and try again.",
             "loading": "Loading Game...",
-            "votingNotStarted": "Voting not started",
             "warriorJoined": "{name} has joined the game",
             "warriorRetreated": "{name} has left the game",
-            "warriorVoted": "{name} has voted",
-            "warriorRetractedVote": "{name} has retracted vote",
-            "warriorNudge": "pst... {name}, waiting on you to vote.",
             "warriorInvite": "Invite a Player",
-            "warriorLeader": "Leader",
-            "finalPoints": "Final Points",
-            "points": "Points",
-            "planSkipped": "Plan skipped",
+            "planSkipped": "Story skipped",
             "voteResults": {
-                "totalVotes": "Total Votes",
-                "average": "Average",
-                "highest": "Highest",
-                "showVoters": "Show Voters",
                 "unknownWarrior": "Unknown Player"
             },
             "battleDeleted": "Game deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Stories",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Game",
     "battles": "Games",
     "battlesActive": "Active Games",
@@ -362,37 +102,6 @@
     "battleJoin": "Join Game",
     "battleRemoveSuccess": "Game removed successfully.",
     "battleRemoveError": "Error attempting to remove game.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team games",
     "sessionDuplicate": "Duplicate game session exists for your ID"
 }

--- a/frontend/public/lang/friendly/ru.json
+++ b/frontend/public/lang/friendly/ru.json
@@ -1,62 +1,19 @@
 {
-    "appName": "Thunderdome",
-    "appVersion": "Версия {version}",
-    "avatarAltText": "Placeholder Avatar",
-    "logout": "Выйти",
-    "logoutError": "Ошибка при попытке выйти из профиля",
     "battleDelete": "Удалить игру",
     "battleAbandon": "Покинуть игру",
     "battleCreate": "Создать игру",
     "battleEdit": "Редактировать игру",
-    "battleEditPointsDisabled": "Нельзя менять карточки пока активно голосование.",
-    "save": "Сохранить",
-    "warriorCreate": "Создать участника",
     "warriorNudge": "Пнуть",
     "promote": "Сделать боссом",
-    "demote": "Demote",
-    "planAdd": "Добавить задачу",
-    "planSkip": "Пропустить задачу",
-    "planName": "Заголовок задачи",
-    "planNamePlaceholder": "Введите заголовок задачи",
-    "planType": "Тип задач",
-    "planTypePlaceholder": "Типы задач",
-    "planLink": "Ссылка",
-    "planLinkPlaceholder": "Введите ссылку на задачу",
-    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
-    "planReferenceId": "ID ссылки",
-    "planReferenceIdPlaceholder": "Введите ID ссылки",
-    "planDescription": "Описание",
-    "planDescriptionPlaceholder": "Введите описание",
-    "planAcceptanceCriteria": "Критерии выполнения",
-    "planAcceptanceCriteriaPlaceholder": "Введите критерии выполнения задачи",
-    "pointed": "Оцененные ({count})",
-    "unpointed": "Неоцененные ({count})",
     "view": "Посмотреть",
-    "activate": "Активировать",
-    "votingFinish": "Закончить голосование",
-    "votingRestart": "Перезапустить голосование",
-    "importJiraXML": "Импорт задач из джиры",
-    "importJiraXMLBadFileTypeError": "Ошибка: плохой тип файла",
-    "importJiraXMLReadFileError": "Ошибка чтения файла",
-    "planTypeStory": "история",
-    "planTypeBug": "ошибка",
-    "planTypeSpike": "spike",
-    "planTypeEpic": "эпик",
-    "planTypeTask": "задача",
-    "planTypeSubtask": "подзадача",
     "landingTitle": "Thunderdome is an Open Source Agile Planning Poker app",
-    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
     "landingBullet2": "Simple Player Experience",
-    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
-    "landingBullet3NotSorry": "*sorry, not sorry IE",
-    "landingFeatures": "Features",
     "landingCountries": "Users in over {count} countries",
     "pages": {
         "myBattles": {
             "nav": "Мои игры",
             "title": "Мои игры",
             "battlesError": "Ошибка поиска ваших игр",
-            "countPlansPointed": "{totalPointed} из {totalPlans} задач оценено",
             "createBattle": {
                 "title": "Создать игру",
                 "createError": "Ошибка создания игры",
@@ -64,297 +21,34 @@
                     "name": {
                         "label": "Название игры",
                         "placeholder": "Введите название игры"
-                    },
-                    "allowedPointValues": {
-                        "label": "Разрешенные карточки"
-                    },
-                    "plans": {
-                        "label": "Задачи",
-                        "addButton": "Добавить задачу",
-                        "removeButton": "Удалить",
-                        "fields": {
-                            "name": {
-                                "placeholder": "Введите заголовок задачи"
-                            }
-                        }
-                    },
-                    "autoFinishVoting": {
-                        "label": "Автозавершение голосования когда все проголосовали"
-                    },
-                    "averageRounding": {
-                        "label": "Method of Point Average Rounding",
-                        "ceil": "Ceil",
-                        "floor": "Floor",
-                        "round": "Round"
                     }
                 }
             }
         },
         "createAccount": {
-            "nav": "Создать профиль",
-            "title": "Зайти в игру",
-            "registrationDisabled": "Регистрация отключена.",
-            "guestForm": {
-                "title": "Войти как гость",
-                "saveButton": "Зарегистировать",
-                "createError": "Ошибка регистрации как гостя",
-                "fields": {
-                    "name": {
-                        "label": "Имя",
-                        "placeholder": "Введите имя"
-                    }
-                }
-            },
-            "createAccountForm": {
-                "saveButton": "Создать",
-                "title": "Создать аккаунт {optionalOpen}(Необязательно){optionalClose}",
-                "createError": "Ошибка создания участника",
-                "fields": {
-                    "name": {
-                        "label": "Имя",
-                        "placeholder": "Введите имя"
-                    },
-                    "email": {
-                        "label": "Электронная почта",
-                        "placeholder": "Введите электронную почту"
-                    },
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Повторите пароль"
-                    }
-                }
-            }
-        },
-        "verifyAccount": {
-            "loading": "Подтверждение профиля...",
-            "verified": {
-                "title": "Профиль подтвержден",
-                "thanks": "Спасибо за подтверждение почты."
-            },
-            "failed": {
-                "title": "Верификация завершилась ошибкой",
-                "error": "Произошла ошибка верификации."
-            }
-        },
-        "warriorProfile": {
-            "title": "Профиль",
-            "errorRetreiving": "Ошибка получения профиля",
-            "errorUpdating": "Ошибка обновления профиля",
-            "updateSuccess": "Profile updated",
-            "passwordUpdated": "Пароль обновлен.",
-            "passwordUpdateError": "Ошибка обновления пароля",
-            "updatePasswordButton": "Обновить пароль",
-            "saveProfileButton": "Обновить профиль",
-            "fields": {
-                "name": {
-                    "label": "Имя",
-                    "placeholder": "Введите имя"
-                },
-                "email": {
-                    "label": "Электронная почта",
-                    "verified": "Подтвержден"
-                },
-                "country": {
-                    "label": "Country",
-                    "placeholder": "Choose your country (optional)"
-                },
-                "company": {
-                    "label": "Company",
-                    "placeholder": "Enter your company (optional)"
-                },
-                "jobTitle": {
-                    "label": "Job Title",
-                    "placeholder": "Enter your job title (optional)"
-                },
-                "avatar": {
-                    "label": "Аватар"
-                },
-                "enable_notifications": {
-                    "label": "Включить уведомления"
-                }
-            },
-            "updatePasswordForm": {
-                "title": "Обновить пароль",
-                "cancelButton": "Отмена",
-                "saveButton": "Обновить",
-                "fields": {
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Повторите пароль"
-                    }
-                }
-            },
-            "apiKeys": {
-                "title": "API Keys",
-                "createButton": "Create API Key",
-                "name": "Key Name",
-                "prefix": "Key Prefix",
-                "active": "Active",
-                "updated": "Last Updated",
-                "actions": "Actions",
-                "activateButton": "Activate",
-                "deactivateButton": "Deactivate",
-                "deleteButton": "Delete",
-                "errorRetreiving": "Failed to get API keys",
-                "createFailed": "Failed to create API Key",
-                "deleteFailed": "Failed to delete API Key",
-                "deleteSuccess": "API Key deleted",
-                "updateSuccess": "API Key updated",
-                "updateFailed": "Failed to update API Key",
-                "fields": {
-                    "name": {
-                        "label": "Key Name",
-                        "placeholder": "Enter a Key Name",
-                        "invalid": "Please enter a key name"
-                    },
-                    "submitButton": "Create",
-                    "closeButton": "Close"
-                },
-                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
-                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
-            },
-            "delete": {
-                "deleteButton": "Delete Account",
-                "error": "Error encountered attempting to delete your account.",
-                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
-                "confirmButton": "Confirm Delete",
-                "cancelButton": "Cancel"
-            }
+            "title": "Зайти в игру"
         },
         "admin": {
-            "nav": "Админка",
-            "title": "Админка",
             "counts": {
-                "registered": "Зарегистрированные участники",
-                "unregistered": "Незарегистрированные",
-                "battles": "Игры",
-                "plans": "Задачи"
-            },
-            "registeredWarriors": {
-                "title": "Зарегистрированные участники",
-                "name": "Имя",
-                "email": "Электронная почта",
-                "country": "Country",
-                "company": "Company",
-                "jobTitle": "Job Title",
-                "verified": "Подтвержден",
-                "rank": "Rank"
+                "battles": "Игры"
             },
             "maintenance": {
-                "title": "Maintenance",
-                "cleanGuests": "Clean Guests older than {daysOld} days",
                 "cleanBattles": "Clean Games older than {daysOld} days"
             }
         },
         "login": {
-            "nav": "Войти",
-            "title": "Войти",
-            "registerForBattle": "or {registerOpen}Войти{registerClose} to join the Game",
-            "button": "Войти",
-            "authError": "Ошибка при попытке авторизации",
-            "sendResetSuccess": "Инструкция по сбросу отправлена на {email}",
-            "sendResetError": "Ошибка при попытки отправить инструкцию сброса",
-            "fields": {
-                "email": {
-                    "label": "Электронная почта",
-                    "placeholder": "Введите электронную почту"
-                },
-                "password": {
-                    "label": "Пароль",
-                    "placeholder": "Введите пароль",
-                    "forgotLabel": "Забыл пароль"
-                }
-            },
-            "passwordReset": {
-                "title": "Сбросить пароль",
-                "resetError": "Ошибка при попытке сбросить пароль",
-                "saveButton": "Сбросить",
-                "fields": {
-                    "password": {
-                        "label": "Пароль",
-                        "placeholder": "Введите пароль"
-                    },
-                    "confirmPassword": {
-                        "label": "Подтвердить пароль",
-                        "placeholder": "Подтвердить пароль"
-                    }
-                }
-            }
+            "registerForBattle": "or {registerOpen}Войти{registerClose} to join the Game"
         },
         "battle": {
             "title": "Игра",
-            "warriors": "Участники",
-            "socketReconnecting": "Упс, перезагрузка списка задач...",
-            "socketError": "Ошибка: обновите страницу или попробуйте позже.",
-            "loading": "Загрузка списка задач...",
-            "votingNotStarted": "Голосование еще не началось",
             "warriorJoined": "{name} присоединился к игре",
             "warriorRetreated": "{name} покинул игру",
-            "warriorVoted": "{name} проголосовал",
-            "warriorRetractedVote": "{name} убрал оценку",
-            "warriorNudge": "Хей... {name}, ждем твоего голоса.",
-            "warriorInvite": "Пригласить участника",
             "warriorLeader": "Создатель",
-            "finalPoints": "Итого голосов",
-            "points": "Голоса",
-            "planSkipped": "Задача пропущена",
-            "voteResults": {
-                "totalVotes": "Всего голосов",
-                "average": "Среднее",
-                "highest": "Лучшее",
-                "showVoters": "Показать проголосовавших",
-                "unknownWarrior": "Неизвестный участник"
-            },
             "battleDeleted": "Game deleted"
         }
     },
-    "footer": {
-        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
-        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
-        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
-    },
-    "name": "Name",
-    "email": "Email",
     "plans": "Stories",
-    "cancel": "Cancel",
-    "delete": "Удалить",
     "edit": "Редактировать",
-    "users": "Users",
-    "type": "Type",
-    "active": "Active",
-    "apiKeys": "API Keys",
-    "dateUpdated": "Updated Date",
-    "dateCreated": "Created Date",
-    "cannotBeUndone": "This cannot be undone.",
-    "userEmail": "User Email",
-    "userEmailPlaceholder": "Enter a registered users email",
-    "userAddSuccess": "User added successfully.",
-    "userAddError": "Error attempting to add user.",
-    "userRemoveSuccess": "User removed successfully.",
-    "userRemoveError": "Error attempting to remove user.",
-    "role": "Role",
-    "rolePlaceholder": "Select users role",
-    "userAdd": "Add User",
-    "flag": "Flag",
-    "alerts": "Alerts",
-    "alertCreate": "Create Alert",
-    "alertNamePlaceholder": "Enter an alert name",
-    "alertTypePlaceholder": "Select an alert type",
-    "alertContent": "Alert Content",
-    "alertContentPlaceholder": "Enter alert content",
-    "alertRegisteredOnly": "Registered Only",
-    "alertAllowDismiss": "Allow Dismiss",
-    "alertSave": "Save Alert",
-    "alertDelete": "Delete Alert",
-    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
     "battle": "Game",
     "battles": "Games",
     "battlesActive": "Active Games",
@@ -362,37 +56,6 @@
     "battleJoin": "Join Game",
     "battleRemoveSuccess": "Game removed successfully.",
     "battleRemoveError": "Error attempting to remove game.",
-    "department": "Department",
-    "departments": "Departments",
-    "departmentCreate": "Create Department",
-    "departmentName": "Department Name",
-    "departmentNamePlaceholder": "Enter an department name",
-    "departmentSave": "Save Department",
-    "departmentGetError": "Error getting department",
-    "departmentUsersGetError": "Error getting department users",
-    "departmentTeamsGetError": "Error getting department teams",
-    "departmentCreateError": "Error attempting to create department",
-    "organization": "Organization",
-    "organizations": "Organizations",
-    "organizationName": "Organization Name",
-    "organizationNamePlaceholder": "Enter an organization name",
-    "organizationSave": "Save Organization",
-    "organizationGetError": "Error getting organization",
-    "organizationGetDepartmentsError": "Error getting organization departments",
-    "organizationGetTeamsError": "Error getting organization teams",
-    "organizationGetUsersError": "Error getting organization users",
-    "team": "Team",
-    "teams": "Teams",
-    "teamCreate": "Create Team",
-    "teamCreateSuccess": "Team created successfully.",
-    "teamCreateError": "Error attempting to create team.",
-    "teamName": "Team Name",
-    "teamNamePlaceholder": "Enter an team name",
-    "teamSave": "Save Team",
-    "teamDeleteSuccess": "Team deleted successfully.",
-    "teamDeleteError": "Error attempting to delete team",
-    "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users",
     "teamGetBattlesError": "Error getting team games",
     "sessionDuplicate": "Duplicate game session exists for your ID"
 }

--- a/frontend/public/lang/pt.json
+++ b/frontend/public/lang/pt.json
@@ -1,0 +1,329 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Version {version}",
+    "avatarAltText": "Placeholder Avatar",
+    "logout": "Logout",
+    "battleEditPointsDisabled": "Voting is active, cannot modify allowed points.",
+    "save": "Save",
+    "warriorNudge": "Nudge",
+    "promote": "Promote",
+    "demote": "Demote",
+    "planTypePlaceholder": "Types",
+    "planLink": "Link",
+    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
+    "planReferenceId": "Reference ID",
+    "planReferenceIdPlaceholder": "Enter a reference ID",
+    "planDescription": "Description",
+    "planDescriptionPlaceholder": "Enter a description",
+    "planAcceptanceCriteria": "Acceptance Criteria",
+    "planAcceptanceCriteriaPlaceholder": "Enter acceptance criteria",
+    "pointed": "Pointed ({count})",
+    "unpointed": "Unpointed ({count})",
+    "view": "View",
+    "activate": "Activate",
+    "votingFinish": "Finish Voting",
+    "votingRestart": "Restart Voting",
+    "importJiraXMLBadFileTypeError": "Error bad file type",
+    "importJiraXMLReadFileError": "Error reading file",
+    "planTypeStory": "Story",
+    "planTypeBug": "Bug",
+    "planTypeSpike": "Spike",
+    "planTypeEpic": "Epic",
+    "planTypeTask": "Task",
+    "planTypeSubtask": "Subtask",
+    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
+    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
+    "landingBullet3NotSorry": "*sorry, not sorry IE",
+    "landingFeatures": "Features",
+    "landingFeatureOpenSourceTitle": "Open Source",
+    "landingFeatureOpenSourceText": "Check out the {githubIcon}{repoOpen}repository{repoClose} to request or contribute enhancements, locale translations and bug fixes or to {donateOpen}Donate{donateClose}",
+    "pages": {
+        "myBattles": {
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Allowed Point Values"
+                    },
+                    "plans": {
+                        "removeButton": "Remove"
+                    },
+                    "averageRounding": {
+                        "label": "Method of Point Average Rounding",
+                        "ceil": "Ceil",
+                        "floor": "Floor",
+                        "round": "Round"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Create Account",
+            "title": "Enlist to Battle",
+            "registrationDisabled": "Registration is disabled.",
+            "guestForm": {
+                "title": "Register as Guest",
+                "saveButton": "Register",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Create",
+                "title": "Create an Account {optionalOpen}(optional){optionalClose}",
+                "createError": "Error encountered creating warrior",
+                "fields": {
+                    "name": {
+                        "label": "Name",
+                        "placeholder": "Enter your name"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "placeholder": "Enter your email"
+                    },
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Verifying Account...",
+            "verified": {
+                "title": "Account Verified",
+                "thanks": "Thanks for verifying your email."
+            },
+            "failed": {
+                "title": "Verification Failed",
+                "error": "Something went wrong verifying your account, perhaps this link expired or was already used."
+            }
+        },
+        "warriorProfile": {
+            "title": "Your Profile",
+            "errorRetreiving": "Error getting your profile",
+            "errorUpdating": "Error encountered updating your profile",
+            "updateSuccess": "Profile updated",
+            "passwordUpdated": "Password updated.",
+            "passwordUpdateError": "Error encountered attempting to update password",
+            "updatePasswordButton": "Update Password",
+            "saveProfileButton": "Update Profile",
+            "fields": {
+                "name": {
+                    "label": "Name",
+                    "placeholder": "Enter your name"
+                },
+                "email": {
+                    "label": "Email",
+                    "verified": "Verified"
+                },
+                "country": {
+                    "label": "Country",
+                    "placeholder": "Choose your country (optional)"
+                },
+                "company": {
+                    "label": "Company",
+                    "placeholder": "Enter your company (optional)"
+                },
+                "jobTitle": {
+                    "label": "Job Title",
+                    "placeholder": "Enter your job title (optional)"
+                },
+                "avatar": {
+                    "label": "Avatar"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Update Password",
+                "cancelButton": "Cancel",
+                "saveButton": "Update",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter a password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Confirm your password"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Keys",
+                "createButton": "Create API Key",
+                "name": "Key Name",
+                "prefix": "Key Prefix",
+                "active": "Active",
+                "updated": "Last Updated",
+                "actions": "Actions",
+                "activateButton": "Activate",
+                "deactivateButton": "Deactivate",
+                "deleteButton": "Delete",
+                "errorRetreiving": "Failed to get API keys",
+                "createFailed": "Failed to create API Key",
+                "deleteFailed": "Failed to delete API Key",
+                "deleteSuccess": "API Key deleted",
+                "updateSuccess": "API Key updated",
+                "updateFailed": "Failed to update API Key",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Enter a Key Name",
+                        "invalid": "Please enter a key name"
+                    },
+                    "submitButton": "Create",
+                    "closeButton": "Close"
+                },
+                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
+                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
+            },
+            "delete": {
+                "deleteButton": "Delete Account",
+                "error": "Error encountered attempting to delete your account.",
+                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
+                "confirmButton": "Confirm Delete",
+                "cancelButton": "Cancel"
+            }
+        },
+        "admin": {
+            "nav": "Admin",
+            "title": "Admin",
+            "registeredWarriors": {
+                "name": "Name",
+                "email": "Email",
+                "country": "Country",
+                "company": "Company",
+                "jobTitle": "Job Title",
+                "verified": "Verified",
+                "rank": "Rank"
+            },
+            "maintenance": {
+                "title": "Maintenance",
+                "cleanGuests": "Clean Guests older than {daysOld} days"
+            }
+        },
+        "login": {
+            "nav": "Login",
+            "title": "Login",
+            "button": "Login",
+            "sendResetSuccess": "Password reset instructions sent to {email}",
+            "sendResetError": "Error encountered attempting to send password reset",
+            "fields": {
+                "email": {
+                    "label": "Email",
+                    "placeholder": "Enter your email"
+                },
+                "password": {
+                    "label": "Password",
+                    "placeholder": "Enter your password",
+                    "forgotLabel": "Forgot Password?"
+                }
+            },
+            "passwordReset": {
+                "title": "Reset Password",
+                "resetError": "Error encountered attempting to reset password",
+                "saveButton": "Reset",
+                "fields": {
+                    "password": {
+                        "label": "Password",
+                        "placeholder": "Enter your new password"
+                    },
+                    "confirmPassword": {
+                        "label": "Confirm Password",
+                        "placeholder": "Enter your new password"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "votingNotStarted": "Voting not started",
+            "warriorVoted": "{name} has voted",
+            "warriorRetractedVote": "{name} has retracted vote",
+            "warriorNudge": "pst... {name}, waiting on you to vote.",
+            "warriorLeader": "Leader",
+            "finalPoints": "Final Points",
+            "points": "Points",
+            "voteResults": {
+                "totalVotes": "Total Votes",
+                "average": "Average",
+                "highest": "Highest",
+                "showVoters": "Show Voters"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "Email",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "users": "Users",
+    "type": "Type",
+    "active": "Active",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Updated Date",
+    "dateCreated": "Created Date",
+    "cannotBeUndone": "This cannot be undone.",
+    "userEmail": "User Email",
+    "userEmailPlaceholder": "Enter a registered users email",
+    "userAddSuccess": "User added successfully.",
+    "userAddError": "Error attempting to add user.",
+    "userRemoveSuccess": "User removed successfully.",
+    "userRemoveError": "Error attempting to remove user.",
+    "role": "Role",
+    "rolePlaceholder": "Select users role",
+    "userAdd": "Add User",
+    "flag": "Flag",
+    "alerts": "Alerts",
+    "alertCreate": "Create Alert",
+    "alertNamePlaceholder": "Enter an alert name",
+    "alertTypePlaceholder": "Select an alert type",
+    "alertContent": "Alert Content",
+    "alertContentPlaceholder": "Enter alert content",
+    "alertRegisteredOnly": "Registered Only",
+    "alertAllowDismiss": "Allow Dismiss",
+    "alertSave": "Save Alert",
+    "alertDelete": "Delete Alert",
+    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
+    "department": "Department",
+    "departments": "Departments",
+    "departmentCreate": "Create Department",
+    "departmentName": "Department Name",
+    "departmentNamePlaceholder": "Enter an department name",
+    "departmentSave": "Save Department",
+    "departmentGetError": "Error getting department",
+    "departmentUsersGetError": "Error getting department users",
+    "departmentTeamsGetError": "Error getting department teams",
+    "departmentCreateError": "Error attempting to create department",
+    "organization": "Organization",
+    "organizations": "Organizations",
+    "organizationName": "Organization Name",
+    "organizationNamePlaceholder": "Enter an organization name",
+    "organizationSave": "Save Organization",
+    "organizationGetError": "Error getting organization",
+    "organizationGetDepartmentsError": "Error getting organization departments",
+    "organizationGetTeamsError": "Error getting organization teams",
+    "organizationGetUsersError": "Error getting organization users",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Create Team",
+    "teamCreateSuccess": "Team created successfully.",
+    "teamCreateError": "Error attempting to create team.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter an team name",
+    "teamSave": "Save Team",
+    "teamDeleteSuccess": "Team deleted successfully.",
+    "teamDeleteError": "Error attempting to delete team",
+    "teamGetError": "Error getting team",
+    "teamGetUsersError": "Error getting team users"
+}

--- a/frontend/public/lang/pt.json
+++ b/frontend/public/lang/pt.json
@@ -331,5 +331,6 @@
     "adminPageAlerts": "Alerts",
     "adminPageOrganizations": "Organizations",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Users"
+    "adminPageUsers": "Users",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/pt.json
+++ b/frontend/public/lang/pt.json
@@ -266,6 +266,7 @@
     "email": "Email",
     "cancel": "Cancel",
     "delete": "Delete",
+    "remove": "Remove",
     "edit": "Edit",
     "users": "Users",
     "type": "Type",
@@ -325,5 +326,10 @@
     "teamDeleteSuccess": "Team deleted successfully.",
     "teamDeleteError": "Error attempting to delete team",
     "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users"
+    "teamGetUsersError": "Error getting team users",
+    "adminPageAdmin": "Admin",
+    "adminPageAlerts": "Alerts",
+    "adminPageOrganizations": "Organizations",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Users"
 }

--- a/frontend/public/lang/ru.json
+++ b/frontend/public/lang/ru.json
@@ -297,6 +297,7 @@
     "email": "Email",
     "cancel": "Cancel",
     "delete": "Удалить",
+    "remove": "Remove",
     "users": "Users",
     "type": "Type",
     "active": "Active",
@@ -355,5 +356,10 @@
     "teamDeleteSuccess": "Team deleted successfully.",
     "teamDeleteError": "Error attempting to delete team",
     "teamGetError": "Error getting team",
-    "teamGetUsersError": "Error getting team users"
+    "teamGetUsersError": "Error getting team users",
+    "adminPageAdmin": "Admin",
+    "adminPageAlerts": "Alerts",
+    "adminPageOrganizations": "Organizations",
+    "adminPageTeams": "Teams",
+    "adminPageUsers": "Users"
 }

--- a/frontend/public/lang/ru.json
+++ b/frontend/public/lang/ru.json
@@ -361,5 +361,6 @@
     "adminPageAlerts": "Alerts",
     "adminPageOrganizations": "Organizations",
     "adminPageTeams": "Teams",
-    "adminPageUsers": "Users"
+    "adminPageUsers": "Users",
+    "adminPageApi": "API Keys"
 }

--- a/frontend/public/lang/ru.json
+++ b/frontend/public/lang/ru.json
@@ -1,0 +1,359 @@
+{
+    "appName": "Thunderdome",
+    "appVersion": "Версия {version}",
+    "avatarAltText": "Placeholder Avatar",
+    "logout": "Выйти",
+    "logoutError": "Ошибка при попытке выйти из профиля",
+    "battleEditPointsDisabled": "Нельзя менять карточки пока активно голосование.",
+    "save": "Сохранить",
+    "warriorCreate": "Создать участника",
+    "demote": "Demote",
+    "planAdd": "Добавить задачу",
+    "planSkip": "Пропустить задачу",
+    "planName": "Заголовок задачи",
+    "planNamePlaceholder": "Введите заголовок задачи",
+    "planType": "Тип задач",
+    "planTypePlaceholder": "Типы задач",
+    "planLink": "Ссылка",
+    "planLinkPlaceholder": "Введите ссылку на задачу",
+    "planLinkInvalid": "Link isn't a valid absolute URL, e.g. includes protocol (HTTP/HTTPS)",
+    "planReferenceId": "ID ссылки",
+    "planReferenceIdPlaceholder": "Введите ID ссылки",
+    "planDescription": "Описание",
+    "planDescriptionPlaceholder": "Введите описание",
+    "planAcceptanceCriteria": "Критерии выполнения",
+    "planAcceptanceCriteriaPlaceholder": "Введите критерии выполнения задачи",
+    "pointed": "Оцененные ({count})",
+    "unpointed": "Неоцененные ({count})",
+    "activate": "Активировать",
+    "votingFinish": "Закончить голосование",
+    "votingRestart": "Перезапустить голосование",
+    "importJiraXML": "Импорт задач из джиры",
+    "importJiraXMLBadFileTypeError": "Ошибка: плохой тип файла",
+    "importJiraXMLReadFileError": "Ошибка чтения файла",
+    "planTypeStory": "история",
+    "planTypeBug": "ошибка",
+    "planTypeSpike": "spike",
+    "planTypeEpic": "эпик",
+    "planTypeTask": "задача",
+    "planTypeSubtask": "подзадача",
+    "landingBullet1": "Built on cool tech like Svelte, Go, and WebSockets",
+    "landingBullet3": "Works on all {mbOpen}modern browsers*{mbClose}, including mobile",
+    "landingBullet3NotSorry": "*sorry, not sorry IE",
+    "landingFeatures": "Features",
+    "pages": {
+        "myBattles": {
+            "countPlansPointed": "{totalPointed} из {totalPlans} задач оценено",
+            "createBattle": {
+                "fields": {
+                    "allowedPointValues": {
+                        "label": "Разрешенные карточки"
+                    },
+                    "plans": {
+                        "label": "Задачи",
+                        "addButton": "Добавить задачу",
+                        "removeButton": "Удалить",
+                        "fields": {
+                            "name": {
+                                "placeholder": "Введите заголовок задачи"
+                            }
+                        }
+                    },
+                    "autoFinishVoting": {
+                        "label": "Автозавершение голосования когда все проголосовали"
+                    },
+                    "averageRounding": {
+                        "label": "Method of Point Average Rounding",
+                        "ceil": "Ceil",
+                        "floor": "Floor",
+                        "round": "Round"
+                    }
+                }
+            }
+        },
+        "createAccount": {
+            "nav": "Создать профиль",
+            "registrationDisabled": "Регистрация отключена.",
+            "guestForm": {
+                "title": "Войти как гость",
+                "saveButton": "Зарегистировать",
+                "createError": "Ошибка регистрации как гостя",
+                "fields": {
+                    "name": {
+                        "label": "Имя",
+                        "placeholder": "Введите имя"
+                    }
+                }
+            },
+            "createAccountForm": {
+                "saveButton": "Создать",
+                "title": "Создать аккаунт {optionalOpen}(Необязательно){optionalClose}",
+                "createError": "Ошибка создания участника",
+                "fields": {
+                    "name": {
+                        "label": "Имя",
+                        "placeholder": "Введите имя"
+                    },
+                    "email": {
+                        "label": "Электронная почта",
+                        "placeholder": "Введите электронную почту"
+                    },
+                    "password": {
+                        "label": "Пароль",
+                        "placeholder": "Введите пароль"
+                    },
+                    "confirmPassword": {
+                        "label": "Подтвердить пароль",
+                        "placeholder": "Повторите пароль"
+                    }
+                }
+            }
+        },
+        "verifyAccount": {
+            "loading": "Подтверждение профиля...",
+            "verified": {
+                "title": "Профиль подтвержден",
+                "thanks": "Спасибо за подтверждение почты."
+            },
+            "failed": {
+                "title": "Верификация завершилась ошибкой",
+                "error": "Произошла ошибка верификации."
+            }
+        },
+        "warriorProfile": {
+            "title": "Профиль",
+            "errorRetreiving": "Ошибка получения профиля",
+            "errorUpdating": "Ошибка обновления профиля",
+            "updateSuccess": "Profile updated",
+            "passwordUpdated": "Пароль обновлен.",
+            "passwordUpdateError": "Ошибка обновления пароля",
+            "updatePasswordButton": "Обновить пароль",
+            "saveProfileButton": "Обновить профиль",
+            "fields": {
+                "name": {
+                    "label": "Имя",
+                    "placeholder": "Введите имя"
+                },
+                "email": {
+                    "label": "Электронная почта",
+                    "verified": "Подтвержден"
+                },
+                "country": {
+                    "label": "Country",
+                    "placeholder": "Choose your country (optional)"
+                },
+                "company": {
+                    "label": "Company",
+                    "placeholder": "Enter your company (optional)"
+                },
+                "jobTitle": {
+                    "label": "Job Title",
+                    "placeholder": "Enter your job title (optional)"
+                },
+                "avatar": {
+                    "label": "Аватар"
+                },
+                "enable_notifications": {
+                    "label": "Включить уведомления"
+                }
+            },
+            "updatePasswordForm": {
+                "title": "Обновить пароль",
+                "cancelButton": "Отмена",
+                "saveButton": "Обновить",
+                "fields": {
+                    "password": {
+                        "label": "Пароль",
+                        "placeholder": "Введите пароль"
+                    },
+                    "confirmPassword": {
+                        "label": "Подтвердить пароль",
+                        "placeholder": "Повторите пароль"
+                    }
+                }
+            },
+            "apiKeys": {
+                "title": "API Keys",
+                "createButton": "Create API Key",
+                "name": "Key Name",
+                "prefix": "Key Prefix",
+                "active": "Active",
+                "updated": "Last Updated",
+                "actions": "Actions",
+                "activateButton": "Activate",
+                "deactivateButton": "Deactivate",
+                "deleteButton": "Delete",
+                "errorRetreiving": "Failed to get API keys",
+                "createFailed": "Failed to create API Key",
+                "deleteFailed": "Failed to delete API Key",
+                "deleteSuccess": "API Key deleted",
+                "updateSuccess": "API Key updated",
+                "updateFailed": "Failed to update API Key",
+                "fields": {
+                    "name": {
+                        "label": "Key Name",
+                        "placeholder": "Enter a Key Name",
+                        "invalid": "Please enter a key name"
+                    },
+                    "submitButton": "Create",
+                    "closeButton": "Close"
+                },
+                "createSuccess": "New Api Key {keyName} created and {onlyNowOpen}it will be displayed only now{onlyNowClose}",
+                "storeWarning": "Please store it somewhere safe because as soon as you navigate away from this page, we will not be able to retrieve or restore this generated token."
+            },
+            "delete": {
+                "deleteButton": "Delete Account",
+                "error": "Error encountered attempting to delete your account.",
+                "warningStatement": "Are you sure you want to delete your account, this cannot be undone.",
+                "confirmButton": "Confirm Delete",
+                "cancelButton": "Cancel"
+            }
+        },
+        "admin": {
+            "nav": "Админка",
+            "title": "Админка",
+            "counts": {
+                "registered": "Зарегистрированные участники",
+                "unregistered": "Незарегистрированные",
+                "plans": "Задачи"
+            },
+            "registeredWarriors": {
+                "title": "Зарегистрированные участники",
+                "name": "Имя",
+                "email": "Электронная почта",
+                "country": "Country",
+                "company": "Company",
+                "jobTitle": "Job Title",
+                "verified": "Подтвержден",
+                "rank": "Rank"
+            },
+            "maintenance": {
+                "title": "Maintenance",
+                "cleanGuests": "Clean Guests older than {daysOld} days"
+            }
+        },
+        "login": {
+            "nav": "Войти",
+            "title": "Войти",
+            "button": "Войти",
+            "authError": "Ошибка при попытке авторизации",
+            "sendResetSuccess": "Инструкция по сбросу отправлена на {email}",
+            "sendResetError": "Ошибка при попытки отправить инструкцию сброса",
+            "fields": {
+                "email": {
+                    "label": "Электронная почта",
+                    "placeholder": "Введите электронную почту"
+                },
+                "password": {
+                    "label": "Пароль",
+                    "placeholder": "Введите пароль",
+                    "forgotLabel": "Забыл пароль"
+                }
+            },
+            "passwordReset": {
+                "title": "Сбросить пароль",
+                "resetError": "Ошибка при попытке сбросить пароль",
+                "saveButton": "Сбросить",
+                "fields": {
+                    "password": {
+                        "label": "Пароль",
+                        "placeholder": "Введите пароль"
+                    },
+                    "confirmPassword": {
+                        "label": "Подтвердить пароль",
+                        "placeholder": "Подтвердить пароль"
+                    }
+                }
+            }
+        },
+        "battle": {
+            "warriors": "Участники",
+            "socketReconnecting": "Упс, перезагрузка списка задач...",
+            "socketError": "Ошибка: обновите страницу или попробуйте позже.",
+            "loading": "Загрузка списка задач...",
+            "votingNotStarted": "Голосование еще не началось",
+            "warriorVoted": "{name} проголосовал",
+            "warriorRetractedVote": "{name} убрал оценку",
+            "warriorNudge": "Хей... {name}, ждем твоего голоса.",
+            "warriorInvite": "Пригласить участника",
+            "finalPoints": "Итого голосов",
+            "points": "Голоса",
+            "planSkipped": "Задача пропущена",
+            "voteResults": {
+                "totalVotes": "Всего голосов",
+                "average": "Среднее",
+                "highest": "Лучшее",
+                "showVoters": "Показать проголосовавших",
+                "unknownWarrior": "Неизвестный участник"
+            }
+        }
+    },
+    "footer": {
+        "authoredBy": "by {authorOpen}Steven Weathers{authorClose}.",
+        "license": "The source code is licensed {licenseOpen}Apache 2.0{licenseClose}.",
+        "poweredBy": "Powered by {svelteOpen}Svelte{svelteClose} and {goOpen}Go{goClose}"
+    },
+    "name": "Name",
+    "email": "Email",
+    "cancel": "Cancel",
+    "delete": "Удалить",
+    "users": "Users",
+    "type": "Type",
+    "active": "Active",
+    "apiKeys": "API Keys",
+    "dateUpdated": "Updated Date",
+    "dateCreated": "Created Date",
+    "cannotBeUndone": "This cannot be undone.",
+    "userEmail": "User Email",
+    "userEmailPlaceholder": "Enter a registered users email",
+    "userAddSuccess": "User added successfully.",
+    "userAddError": "Error attempting to add user.",
+    "userRemoveSuccess": "User removed successfully.",
+    "userRemoveError": "Error attempting to remove user.",
+    "role": "Role",
+    "rolePlaceholder": "Select users role",
+    "userAdd": "Add User",
+    "flag": "Flag",
+    "alerts": "Alerts",
+    "alertCreate": "Create Alert",
+    "alertNamePlaceholder": "Enter an alert name",
+    "alertTypePlaceholder": "Select an alert type",
+    "alertContent": "Alert Content",
+    "alertContentPlaceholder": "Enter alert content",
+    "alertRegisteredOnly": "Registered Only",
+    "alertAllowDismiss": "Allow Dismiss",
+    "alertSave": "Save Alert",
+    "alertDelete": "Delete Alert",
+    "alertDeleteConfirmation": "Are you sure you want to delete this alert?",
+    "department": "Department",
+    "departments": "Departments",
+    "departmentCreate": "Create Department",
+    "departmentName": "Department Name",
+    "departmentNamePlaceholder": "Enter an department name",
+    "departmentSave": "Save Department",
+    "departmentGetError": "Error getting department",
+    "departmentUsersGetError": "Error getting department users",
+    "departmentTeamsGetError": "Error getting department teams",
+    "departmentCreateError": "Error attempting to create department",
+    "organization": "Organization",
+    "organizations": "Organizations",
+    "organizationName": "Organization Name",
+    "organizationNamePlaceholder": "Enter an organization name",
+    "organizationSave": "Save Organization",
+    "organizationGetError": "Error getting organization",
+    "organizationGetDepartmentsError": "Error getting organization departments",
+    "organizationGetTeamsError": "Error getting organization teams",
+    "organizationGetUsersError": "Error getting organization users",
+    "team": "Team",
+    "teams": "Teams",
+    "teamCreate": "Create Team",
+    "teamCreateSuccess": "Team created successfully.",
+    "teamCreateError": "Error attempting to create team.",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter an team name",
+    "teamSave": "Save Team",
+    "teamDeleteSuccess": "Team deleted successfully.",
+    "teamDeleteError": "Error attempting to delete team",
+    "teamGetError": "Error getting team",
+    "teamGetUsersError": "Error getting team users"
+}

--- a/frontend/src/components/AdminPageLayout.svelte
+++ b/frontend/src/components/AdminPageLayout.svelte
@@ -8,23 +8,28 @@
 
     const pages = [
         {
-            name: $_('adminPageAdmin'),
+            name: 'Admin',
+            label: $_('adminPageAdmin'),
             path: '',
         },
         {
-            name: $_('adminPageAlerts'),
+            name: 'Alerts',
+            label: $_('adminPageAlerts'),
             path: '/alerts',
         },
         {
-            name: $_('adminPageOrganizations'),
+            name: 'Organizations',
+            label: $_('adminPageOrganizations'),
             path: '/organizations',
         },
         {
-            name: $_('adminPageTeams'),
+            name: 'Teams',
+            label: $_('adminPageTeams'),
             path: '/teams',
         },
         {
-            name: $_('adminPageUsers'),
+            name: 'Users',
+            label: $_('adminPageUsers'),
             path: '/users',
         },
     ]
@@ -32,6 +37,7 @@
     if (APIEnabled) {
         pages.push({
             name: 'API Keys',
+            label: $_('adminPageApi'),
             path: '/apikeys',
         })
     }
@@ -59,7 +65,7 @@
                     <a
                         class="admin-nav-pill {activePage === page.name.toLowerCase() ? activePillClasses : nonActivePillClasses}"
                         href="{appRoutes.admin}{page.path}">
-                        {page.name}
+                        {page.label}
                     </a>
                 </li>
             {/each}

--- a/frontend/src/components/AdminPageLayout.svelte
+++ b/frontend/src/components/AdminPageLayout.svelte
@@ -8,23 +8,23 @@
 
     const pages = [
         {
-            name: 'Admin',
+            name: $_('adminPageAdmin'),
             path: '',
         },
         {
-            name: 'Alerts',
+            name: $_('adminPageAlerts'),
             path: '/alerts',
         },
         {
-            name: 'Organizations',
+            name: $_('adminPageOrganizations'),
             path: '/organizations',
         },
         {
-            name: 'Teams',
+            name: $_('adminPageTeams'),
             path: '/teams',
         },
         {
-            name: 'Users',
+            name: $_('adminPageUsers'),
             path: '/users',
         },
     ]

--- a/frontend/src/components/CreateBattle.svelte
+++ b/frontend/src/components/CreateBattle.svelte
@@ -189,7 +189,9 @@
                 id="averageRounding"
                 name="averageRounding">
                 {#each allowedPointAverages as item}
-                    <option value="{item}">{$_('pages.myBattles.createBattle.fields.averageRounding.' + item)}</option>
+                    <option value="{item}">
+                        {$_('pages.myBattles.createBattle.fields.averageRounding.' + item)}
+                    </option>
                 {/each}
             </select>
             <div

--- a/frontend/src/components/EditBattle.svelte
+++ b/frontend/src/components/EditBattle.svelte
@@ -102,7 +102,9 @@
                     id="averageRounding"
                     name="averageRounding">
                     {#each allowedPointAverages as item}
-                        <option value="{item}">{$_('pages.myBattles.createBattle.fields.averageRounding.' + item)}</option>
+                        <option value="{item}">
+                            {$_('pages.myBattles.createBattle.fields.averageRounding.' + item)}
+                        </option>
                     {/each}
                 </select>
                 <div

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -37,32 +37,32 @@ function setupI18n(options = {}) {
             '{locale}',
             locale_,
         )
-
-        // Download translation file for given locale/language
-        loadJson(messagesFileUrlBase).then(messages => {
-            //console.log("Load base file: " + messagesFileUrlBase)
-
-            // Add messages for locale
-            addMessages(locale_, messages)
-        })
-
         const messageFileUrlAdd = MESSAGE_FILE_URL_ADD.replace(
             '{locale}',
             locale_,
         )
 
-        // Download additional translation file (default/friendly) for given locale/language
-        loadJson(messageFileUrlAdd).then(messages => {
-            //console.log("Load additional file: " + messageFileUrlAdd)
+        // Download basic translation file for given locale/language
+        return loadJson(messagesFileUrlBase).then(messagesBase => {
+            // console.log("Load base file: " + messagesFileUrlBase)
 
-            // Configure svelte-i18n to use the locale
-            _activeLocale = locale_
-            locale.set(locale_)
+            // Add basic messages for locale
+            addMessages(locale_, messagesBase)
 
-            addMessages(locale_, messages)
+            // Download additional translation file (default/friendly) for given locale/language
+            loadJson(messageFileUrlAdd).then(messagesAdd => {
+                // console.log("Load additional file: " + messageFileUrlAdd)
+
+                // Configure svelte-i18n to use the locale
+                _activeLocale = locale_
+                locale.set(locale_)
+
+                // add experience messages for the locale
+                addMessages(locale_, messagesAdd)
+
+                isDownloading.set(false)
+            })
         })
-
-        isDownloading.set(false)
     }
 }
 

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -14,7 +14,8 @@ import { locales, fallbackLocale, PathPrefix } from './config'
 
 const { AppVersion, FriendlyUIVerbs } = appConfig
 const verbsType = FriendlyUIVerbs ? 'friendly' : 'default'
-const MESSAGE_FILE_URL_TEMPLATE = `${PathPrefix}/lang/${verbsType}/{locale}.json?v=${AppVersion}`
+const MESSAGE_FILE_URL_BASE = `${PathPrefix}/lang/{locale}.json?v=${AppVersion}`
+const MESSAGE_FILE_URL_ADD = `${PathPrefix}/lang/${verbsType}/{locale}.json?v=${AppVersion}`
 
 let _activeLocale
 
@@ -32,22 +33,36 @@ function setupI18n(options = {}) {
     if (!hasLoadedLocale(locale_)) {
         isDownloading.set(true)
 
-        const messagesFileUrl = MESSAGE_FILE_URL_TEMPLATE.replace(
+        const messagesFileUrlBase = MESSAGE_FILE_URL_BASE.replace(
             '{locale}',
             locale_,
         )
 
         // Download translation file for given locale/language
-        return loadJson(messagesFileUrl).then(messages => {
-            _activeLocale = locale_
+        loadJson(messagesFileUrlBase).then(messages => {
+            //console.log("Load base file: " + messagesFileUrlBase)
+
+            // Add messages for locale
+            addMessages(locale_, messages)
+        })
+
+        const messageFileUrlAdd = MESSAGE_FILE_URL_ADD.replace(
+            '{locale}',
+            locale_,
+        )
+
+        // Download additional translation file (default/friendly) for given locale/language
+        loadJson(messageFileUrlAdd).then(messages => {
+            //console.log("Load additional file: " + messageFileUrlAdd)
 
             // Configure svelte-i18n to use the locale
-            addMessages(locale_, messages)
-
+            _activeLocale = locale_
             locale.set(locale_)
 
-            isDownloading.set(false)
+            addMessages(locale_, messages)
         })
+
+        isDownloading.set(false)
     }
 }
 

--- a/frontend/src/pages/Landing.svelte
+++ b/frontend/src/pages/Landing.svelte
@@ -93,8 +93,21 @@
         </div>
         <div class="flex text-center mb-8">
             <div class="w-1/2">
-                <h3 class="text-2xl font-bold">Open Source</h3>
+                <h3 class="text-2xl font-bold">
+                    {$_('landingFeatureOpenSourceTitle')}
+                </h3>
                 <p class="px-2">
+                    {@html $_('landingFeatureOpenSourceText', {
+                        values: {
+                            githubIcon: GithubIcon,
+                            repoOpen: `<a href="https://github.com/StevenWeathers/thunderdome-planning-poker" class="feature-link">`,
+                            repoClose: '</a>',
+                            donateOpen: `<a href="https://github.com/StevenWeathers/thunderdome-planning-poker#donations" class="feature-link">`,
+                            donateClose: `</a>`,
+                        },
+                    })}
+                    <br />
+                    <br />
                     Check out the
                     <GithubIcon />
                     <a

--- a/frontend/src/pages/Landing.svelte
+++ b/frontend/src/pages/Landing.svelte
@@ -93,21 +93,8 @@
         </div>
         <div class="flex text-center mb-8">
             <div class="w-1/2">
-                <h3 class="text-2xl font-bold">
-                    {$_('landingFeatureOpenSourceTitle')}
-                </h3>
+                <h3 class="text-2xl font-bold">Open Source</h3>
                 <p class="px-2">
-                    {@html $_('landingFeatureOpenSourceText', {
-                        values: {
-                            githubIcon: GithubIcon,
-                            repoOpen: `<a href="https://github.com/StevenWeathers/thunderdome-planning-poker" class="feature-link">`,
-                            repoClose: '</a>',
-                            donateOpen: `<a href="https://github.com/StevenWeathers/thunderdome-planning-poker#donations" class="feature-link">`,
-                            donateClose: `</a>`,
-                        },
-                    })}
-                    <br />
-                    <br />
                     Check out the
                     <GithubIcon />
                     <a


### PR DESCRIPTION
Basis file (/lang/<locale>.json) contains all items that were identical in default & friendly.
The latter files contain only those values that are different (e.g warrior, battle, ...).

I tested this for locales en & de. If you like this idea I can do the separation also for the rest of the languages and attach them to this PR, too.

Please let me know what you think. 