### PR TITLE
Added Header Authentication

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -39,6 +39,8 @@ type Config struct {
 	SecureCookieFlag bool
 	// Whether LDAP is enabled for authentication
 	LdapEnabled bool
+	// Whether header authentication is enabled
+	HeaderAuthEnabled bool
 	// Feature flag for Poker Planning
 	FeaturePoker bool
 	// Feature flag for Retrospectives
@@ -129,6 +131,8 @@ func Init(config *Config, router *mux.Router, database *db.Database, email *emai
 	// user authentication, profile
 	if a.config.LdapEnabled {
 		apiRouter.HandleFunc("/auth/ldap", a.handleLdapLogin()).Methods("POST")
+	} else if a.config.HeaderAuthEnabled {
+		apiRouter.HandleFunc("/auth", a.handleHeaderLogin()).Methods("GET")
 	} else {
 		apiRouter.HandleFunc("/auth", a.handleLogin()).Methods("POST")
 		apiRouter.HandleFunc("/auth/forgot-password", a.handleForgotPassword()).Methods("POST")

--- a/config.go
+++ b/config.go
@@ -85,6 +85,8 @@ func InitConfig(logger *otelzap.Logger) {
 	viper.SetDefault("auth.ldap.filter", "(&(objectClass=posixAccount)(mail=%s))")
 	viper.SetDefault("auth.ldap.mail_attr", "mail")
 	viper.SetDefault("auth.ldap.cn_attr", "cn")
+	viper.SetDefault("auth.header.usernameHeader", "Remote-User")
+	viper.SetDefault("auth.header.emailHeader", "Remote-Email")
 
 	viper.BindEnv("http.cookie_hashkey", "COOKIE_HASHKEY")
 	viper.BindEnv("http.port", "PORT")
@@ -157,6 +159,8 @@ func InitConfig(logger *otelzap.Logger) {
 	viper.BindEnv("auth.ldap.filter", "AUTH_LDAP_FILTER")
 	viper.BindEnv("auth.ldap.mail_attr", "AUTH_LDAP_MAIL_ATTR")
 	viper.BindEnv("auth.ldap.cn_attr", "AUTH_LDAP_CN_ATTR")
+	viper.BindEnv("auth.header.usernameHeader", "AUTH_HEADER_USERNAME_HEADER")
+	viper.BindEnv("auth.header.emailHeader", "AUTH_HEADER_EMAIL_HEADER")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,7 +97,7 @@ set that user as ADMIN role.
 | `config.cleanup_guests_days_old`      | CONFIG_CLEANUP_GUESTS_DAYS_OLD      | How many days back to clean up old guests, e.g. guests older than 180 days. Triggered manually by Admins.            | 180                                    |
 | `config.organizations_enabled`        | CONFIG_ORGANIZATIONS_ENABLED        | Whether or not creating organizations (with departments) are enabled                                                 | true                                   |
 | `config.require_teams`                | CONFIG_REQUIRE_TEAMS                | Whether or not creating battles, retros, and storyboards require being associated to a Team                          | false                                  |
-| `auth.method`                         | AUTH_METHOD                         | Choose `normal` or `ldap` as authentication method. See separate section on LDAP configuration.                      | normal                                 |
+| `auth.method`                         | AUTH_METHOD                         | Choose `normal`, `header` or `ldap` as authentication method. See separate sections on LDAP/header configurations.   | normal                                 |
 | `feature.poker`                       | FEATURE_POKER                       | Enable or Disable Agile Story Pointing (Poker) feature                                                               | true                                   |
 | `feature.retro`                       | FEATURE_RETRO                       | Enable or Disable Agile Retrospectives feature                                                                       | true                                   |
 | `feature.storyboard`                  | FEATURE_STORYBOARD                  | Enable or Disable Agile Storyboard feature                                                                           | true                                   |
@@ -164,3 +164,15 @@ ldapsearch -H auth.ldap.url [-Z] -x [-D auth.ldap.bindname -W] -b auth.ldap.base
 
 The `-Z` is only used if `auth.ldap.use_tls` is set, the `-D` and `-W` parameter is only used if `auth.ldap.bindname` is
 set.
+
+### Header auth Configuration
+
+If `auth.method` is set to `header`, then the Create Account function is disabled and authentication is done using headers.
+The assumption being that the only access to thunderdome is via a reverseproxy
+
+The following configuration options are specific to the LDAP authentication method:
+
+| Option                      | Environment Variable        | Default        | Description                               |
+| --------------------------- | --------------------------- | -------------- | ----------------------------------------- |
+| `auth.header.usernameHeader`| AUTH_HEADER_USERNAME_HEADER | `Remote-User`  | The header to use for the user's username |
+| `auth.header.emailHeader`   | AUTH_HEADER_EMAIL_HEADER    | `Remote-Email` |The header to use for the user's email     |

--- a/frontend/src/components/user/ProfileForm.svelte
+++ b/frontend/src/components/user/ProfileForm.svelte
@@ -33,6 +33,7 @@
     export let notifications
     export let xfetch
     export let ldapEnabled
+    export let headerAuthEnabled
 
     const { AvatarService } = AppConfig
 
@@ -158,7 +159,7 @@
             id="yourName"
             name="yourName"
             type="text"
-            disabled="{ldapEnabled}"
+            disabled="{ldapEnabled || headerAuthEnabled}"
             required
         />
     </div>
@@ -379,7 +380,7 @@
 
     <div>
         <div class="text-right">
-            {#if !ldapEnabled && toggleUpdatePassword}
+            {#if !ldapEnabled && !headerAuthEnabled && toggleUpdatePassword}
                 <button
                     type="button"
                     class="inline-block align-baseline font-bold

--- a/frontend/src/components/user/UpdatePasswordForm.svelte
+++ b/frontend/src/components/user/UpdatePasswordForm.svelte
@@ -8,7 +8,7 @@
     export let toggleForm = () => {}
     export let notifications
 
-    const { LdapEnabled } = AppConfig
+    const { LdapEnabled, HeaderAuthEnabled } = AppConfig
 
     let warriorPassword1 = ''
     let warriorPassword2 = ''
@@ -34,7 +34,7 @@
     }
 
     $: updatePasswordDisabled =
-        warriorPassword1 === '' || warriorPassword2 === '' || LdapEnabled
+        warriorPassword1 === '' || warriorPassword2 === '' || LdapEnabled || HeaderAuthEnabled
 </script>
 
 <form on:submit="{updateWarriorPassword}" name="updateWarriorPassword">

--- a/frontend/src/pages/UserProfile.svelte
+++ b/frontend/src/pages/UserProfile.svelte
@@ -24,7 +24,7 @@
 
     let updatePassword = false
 
-    const { ExternalAPIEnabled, LdapEnabled } = AppConfig
+    const { ExternalAPIEnabled, LdapEnabled, HeaderAuthEnabled } = AppConfig
 
     function toggleUpdatePassword() {
         updatePassword = !updatePassword
@@ -218,6 +218,7 @@
                         notifications="{notifications}"
                         eventTag="{eventTag}"
                         ldapEnabled="{LdapEnabled}"
+                        headerAuthEnabled="{HeaderAuthEnabled}"
                     />
                 </div>
             {/if}
@@ -416,7 +417,7 @@
             {/if}
         </div>
 
-        {#if !LdapEnabled}
+        {#if !LdapEnabled && !HeaderAuthEnabled}
             <div class="w-full text-center mt-8">
                 <HollowButton onClick="{toggleDeleteAccount}" color="red">
                     {$_('pages.warriorProfile.delete.deleteButton')}

--- a/http.go
+++ b/http.go
@@ -52,6 +52,7 @@ func (s *server) routes() {
 		ExternalAPIEnabled:   s.config.ExternalAPIEnabled,
 		UserAPIKeyLimit:      s.config.UserAPIKeyLimit,
 		LdapEnabled:          s.config.LdapEnabled,
+		HeaderAuthEnabled:    s.config.HeaderAuthEnabled,
 		FeaturePoker:         viper.GetBool("feature.poker"),
 		FeatureRetro:         viper.GetBool("feature.retro"),
 		FeatureStoryboard:    viper.GetBool("feature.storyboard"),
@@ -126,6 +127,7 @@ func (s *server) handleIndex(FSS fs.FS) http.HandlerFunc {
 		CleanupStoryboardsDaysOld int
 		ShowActiveCountries       bool
 		LdapEnabled               bool
+		HeaderAuthEnabled         bool
 		FeaturePoker              bool
 		FeatureRetro              bool
 		FeatureStoryboard         bool
@@ -163,6 +165,7 @@ func (s *server) handleIndex(FSS fs.FS) http.HandlerFunc {
 		CleanupStoryboardsDaysOld: viper.GetInt("config.cleanup_storyboards_days_old"),
 		ShowActiveCountries:       viper.GetBool("config.show_active_countries"),
 		LdapEnabled:               s.config.LdapEnabled,
+		HeaderAuthEnabled:         s.config.HeaderAuthEnabled,
 		FeaturePoker:              viper.GetBool("feature.poker"),
 		FeatureRetro:              viper.GetBool("feature.retro"),
 		FeatureStoryboard:         viper.GetBool("feature.storyboard"),

--- a/main.go
+++ b/main.go
@@ -60,6 +60,8 @@ type Config struct {
 	UserAPIKeyLimit int
 	// Whether LDAP is enabled for authentication
 	LdapEnabled bool
+	// Whether header authentication is enabled
+	HeaderAuthEnabled bool
 }
 
 type server struct {
@@ -118,6 +120,7 @@ func main() {
 			ExternalAPIEnabled: viper.GetBool("config.allow_external_api"),
 			UserAPIKeyLimit:    viper.GetInt("config.user_apikey_limit"),
 			LdapEnabled:        viper.GetString("auth.method") == "ldap",
+			HeaderAuthEnabled:  viper.GetString("auth.method") == "header",
 		},
 		router: router,
 		cookie: securecookie.New([]byte(cookieHashkey), nil),


### PR DESCRIPTION
My use-case is that I have Thunderdome behind a reverse-proxy (Traefik/HAProxy) which handles authentication for me (In this case I'm using SSL client certs)

The changes here enable Thunderdome to authenticate based on given HTTP headers

The assumption is that Thunderdome is not accessible by any other means aside from the reverse-proxy which also wipes the auth headers to prevent masquerading

I mainly just ctrl+f'd for the LDAP auth code and followed it around. I've confirmed it works with my reverse proxy

Sorry if I missed anything, only my second time touching anything using go 😃