### PR TITLE
totalPoints key is missing in pt.json lang file

### DIFF
--- a/frontend/public/lang/pt.json
+++ b/frontend/public/lang/pt.json
@@ -27,6 +27,7 @@
   "planAcceptanceCriteriaPlaceholder": "Insira os critérios de aceitação",
   "pointed": "Pontuado ({count})",
   "unpointed": "Sem pontuação ({count})",
+  "totalPoints": "Total",
   "Visualizar": "Visualizar",
   "activate": "Ativar",
   "votingFinish": "Encerrar votação",


### PR DESCRIPTION
Accessing the https://thunderdome.dev/ website. When you set 'portuguese' as default language,  when you look to the total of a battle the lable is rendered as 'totalPoints' and not the word 'Total'.

The word 'total' in portuguese has the same meaning as in english.