### PR TITLE
update maildev image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       COOKIE_SECURE: "false"
       SMTP_SECURE: "false"
       SMTP_HOST: mail
+      SMTP_PORT: 1025
       DB_NAME: thunderdome
       DB_USER: thor
       DB_PASS: odinson
@@ -38,11 +39,11 @@ services:
     networks:
       - asgard
   mail:
-    image: djfarrelly/maildev:1.1.0
+    image: maildev/maildev:2.0.5
     restart: always
     ports:
-      - 1080:80
-      - 1025:25
+      - 1080:1080
+      - 1025:1025
     networks:
       - asgard
 


### PR DESCRIPTION
As it's stated on [this page](https://hub.docker.com/r/djfarrelly/maildev) the maildev repo has been renamed so I changed the repo and also updated to the new version and the default port on the new maildev version was changed so I this those into effect too.
I tested and it works okay.

PS: thanks for your great opensource project.