### PR TITLE
fix: Failure to Navigate to Teams Page from Navigation Menu on Thunderdome Mobile Website

### DIFF
--- a/frontend/src/components/GlobalHeader.svelte
+++ b/frontend/src/components/GlobalHeader.svelte
@@ -303,7 +303,7 @@
                     {#if $warrior.rank !== 'GUEST' && $warrior.rank !== 'PRIVATE'}
                         <li>
                             <a
-                                href="{appRoutes.organizations}"
+                                href="{appRoutes.teams}"
                                 class="block p-4 hover:bg-green-500 dark:hover:bg-yellow-400 hover:text-white dark:hover:text-gray-800 transition duration-300"
                             >
                                 {$LL.teams()}


### PR DESCRIPTION
This resolves #427 