### PR TITLE
ci: remove unnecessary and failing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Clear
-        if: always()
-        run: rm -f ${ HOME }/.docker/config.json


### PR DESCRIPTION
The VM is automatically deleted after the execution, there is no need to clear this file.