### PR TITLE
Optimize retro group item move and name change socket events

### DIFF
--- a/internal/db/retro/item.go
+++ b/internal/db/retro/item.go
@@ -36,17 +36,22 @@ func (d *Service) CreateRetroItem(RetroID string, UserID string, ItemType string
 }
 
 // GroupRetroItem changes the group_id of retro item
-func (d *Service) GroupRetroItem(RetroID string, ItemId string, GroupId string) ([]*thunderdome.RetroItem, error) {
-	if _, err := d.DB.Exec(
-		`UPDATE thunderdome.retro_item SET group_id = $3 WHERE retro_id = $1 AND id = $2;`,
+func (d *Service) GroupRetroItem(RetroID string, ItemId string, GroupId string) (thunderdome.RetroItem, error) {
+	ri := thunderdome.RetroItem{}
+
+	err := d.DB.QueryRow(
+		`UPDATE thunderdome.retro_item SET group_id = $3
+ 				WHERE retro_id = $1 AND id = $2
+ 				RETURNING id, user_id, group_id, content, type;`,
 		RetroID, ItemId, GroupId,
-	); err != nil {
-		d.Logger.Error("update retro item error", zap.Error(err))
+	).Scan(&ri.ID, &ri.UserID, &ri.GroupID, &ri.Content, &ri.Type)
+
+	if err != nil {
+		d.Logger.Error("move (group) retro item error", zap.Error(err))
+		return ri, err
 	}
 
-	items := d.GetRetroItems(RetroID)
-
-	return items, nil
+	return ri, nil
 }
 
 // DeleteRetroItem removes item from the current board by ID
@@ -112,17 +117,22 @@ func (d *Service) GetRetroGroups(RetroID string) []*thunderdome.RetroGroup {
 }
 
 // GroupNameChange changes retro item group name
-func (d *Service) GroupNameChange(RetroID string, GroupId string, Name string) ([]*thunderdome.RetroGroup, error) {
-	if _, err := d.DB.Exec(
-		`UPDATE thunderdome.retro_group SET name = $3 WHERE retro_id = $1 AND id = $2;`,
+func (d *Service) GroupNameChange(RetroID string, GroupId string, Name string) (thunderdome.RetroGroup, error) {
+	rg := thunderdome.RetroGroup{}
+
+	err := d.DB.QueryRow(
+		`UPDATE thunderdome.retro_group SET name = $3
+				WHERE retro_id = $1 AND id = $2
+				RETURNING id, name;`,
 		RetroID, GroupId, Name,
-	); err != nil {
-		d.Logger.Error("update retro group error", zap.Error(err))
+	).Scan(&rg.ID, &rg.Name)
+
+	if err != nil {
+		d.Logger.Error("update retro group name error", zap.Error(err))
+		return rg, err
 	}
 
-	groups := d.GetRetroGroups(RetroID)
-
-	return groups, nil
+	return rg, nil
 }
 
 // GetRetroVotes gets retro votes

--- a/internal/http/retro/events.go
+++ b/internal/http/retro/events.go
@@ -42,13 +42,13 @@ func (b *Service) GroupItem(ctx context.Context, RetroID string, UserID string, 
 		return nil, err, false
 	}
 
-	items, err := b.RetroService.GroupRetroItem(RetroID, rs.ItemId, rs.GroupId)
+	item, err := b.RetroService.GroupRetroItem(RetroID, rs.ItemId, rs.GroupId)
 	if err != nil {
 		return nil, err, false
 	}
 
-	updatedItems, _ := json.Marshal(items)
-	msg := createSocketEvent("items_updated", string(updatedItems), "")
+	updatedItem, _ := json.Marshal(item)
+	msg := createSocketEvent("item_moved", string(updatedItem), "")
 
 	return msg, nil, false
 }
@@ -87,13 +87,13 @@ func (b *Service) GroupNameChange(ctx context.Context, RetroID string, UserID st
 		return nil, err, false
 	}
 
-	groups, err := b.RetroService.GroupNameChange(RetroID, rs.GroupId, rs.Name)
+	group, err := b.RetroService.GroupNameChange(RetroID, rs.GroupId, rs.Name)
 	if err != nil {
 		return nil, err, false
 	}
 
-	updatedGroups, _ := json.Marshal(groups)
-	msg := createSocketEvent("groups_updated", string(updatedGroups), "")
+	updatedGroup, _ := json.Marshal(group)
+	msg := createSocketEvent("group_name_updated", string(updatedGroup), "")
 
 	return msg, nil, false
 }

--- a/thunderdome/retro.go
+++ b/thunderdome/retro.go
@@ -115,11 +115,11 @@ type RetroDataSvc interface {
 	RetroActionAssigneeDelete(RetroID string, ActionID string, UserID string) ([]*RetroAction, error)
 
 	CreateRetroItem(RetroID string, UserID string, ItemType string, Content string) ([]*RetroItem, error)
-	GroupRetroItem(RetroID string, ItemId string, GroupId string) ([]*RetroItem, error)
+	GroupRetroItem(RetroID string, ItemId string, GroupId string) (RetroItem, error)
 	DeleteRetroItem(RetroID string, userID string, Type string, ItemID string) ([]*RetroItem, error)
 	GetRetroItems(RetroID string) []*RetroItem
 	GetRetroGroups(RetroID string) []*RetroGroup
-	GroupNameChange(RetroID string, GroupId string, Name string) ([]*RetroGroup, error)
+	GroupNameChange(RetroID string, GroupId string, Name string) (RetroGroup, error)
 	GetRetroVotes(RetroID string) []*RetroVote
 	GroupUserVote(RetroID string, GroupID string, UserID string) ([]*RetroVote, error)
 	GroupUserSubtractVote(RetroID string, GroupID string, UserID string) ([]*RetroVote, error)

--- a/ui/src/pages/retro/Retro.svelte
+++ b/ui/src/pages/retro/Retro.svelte
@@ -97,7 +97,7 @@
         return b.votes.length - a.votes.length;
       });
     }
-    if (retro.phase === 'group' || retro.phase === 'vote') {
+    if (retro.phase === 'vote') {
       result.sort((a, b) => {
         return b.items.length - a.items.length;
       });
@@ -156,6 +156,31 @@
         if (retro.phase !== 'brainstorm') {
           groupedItems = organizeItemsByGroup();
         }
+        break;
+      }
+      case 'item_moved': {
+        const parsedValue = JSON.parse(parsedEvent.value);
+        const updatedItems = [...retro.items];
+        console.log(updatedItems);
+        const idx = updatedItems.findIndex(item => {
+          return item.id === parsedValue.id;
+        });
+        console.log(idx);
+        updatedItems[idx].groupId = parsedValue.groupId;
+        console.log(updatedItems);
+        retro.items = updatedItems;
+        groupedItems = organizeItemsByGroup();
+        break;
+      }
+      case 'group_name_updated': {
+        const parsedValue = JSON.parse(parsedEvent.value);
+        const updatedGroups = [...retro.groups];
+        const idx = updatedGroups.findIndex(group => {
+          return group.id === parsedValue.id;
+        });
+        updatedGroups[idx].name = parsedValue.name;
+        retro.groups = updatedGroups;
+        groupedItems = organizeItemsByGroup();
         break;
       }
       case 'groups_updated': {


### PR DESCRIPTION
Also remove reordering of groups during grouping phase as it tends to be jarring and cause too many updates in svelte.