### PR TITLE
Add timer to retro feature brainstorm phase

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -8560,6 +8560,12 @@ const docTemplate = `{
                     "maximum": 9,
                     "minimum": 1
                 },
+                "phaseTimeLimitMin": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0,
+                    "example": 10
+                },
                 "retroName": {
                     "type": "string",
                     "example": "sprint 10 retro"
@@ -9278,6 +9284,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "phase": {
+                    "type": "string"
+                },
+                "phase_time_limit_min": {
+                    "type": "integer"
+                },
+                "phase_time_start": {
                     "type": "string"
                 },
                 "readyUsers": {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -8560,6 +8560,9 @@ const docTemplate = `{
                     "maximum": 9,
                     "minimum": 1
                 },
+                "phaseAutoAdvance": {
+                    "type": "boolean"
+                },
                 "phaseTimeLimitMin": {
                     "type": "integer",
                     "maximum": 59,
@@ -9285,6 +9288,9 @@ const docTemplate = `{
                 },
                 "phase": {
                     "type": "string"
+                },
+                "phase_auto_advance": {
+                    "type": "boolean"
                 },
                 "phase_time_limit_min": {
                     "type": "integer"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -8551,6 +8551,12 @@
                     "maximum": 9,
                     "minimum": 1
                 },
+                "phaseTimeLimitMin": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0,
+                    "example": 10
+                },
                 "retroName": {
                     "type": "string",
                     "example": "sprint 10 retro"
@@ -9269,6 +9275,12 @@
                     "type": "string"
                 },
                 "phase": {
+                    "type": "string"
+                },
+                "phase_time_limit_min": {
+                    "type": "integer"
+                },
+                "phase_time_start": {
                     "type": "string"
                 },
                 "readyUsers": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -8551,6 +8551,9 @@
                     "maximum": 9,
                     "minimum": 1
                 },
+                "phaseAutoAdvance": {
+                    "type": "boolean"
+                },
                 "phaseTimeLimitMin": {
                     "type": "integer",
                     "maximum": 59,
@@ -9276,6 +9279,9 @@
                 },
                 "phase": {
                     "type": "string"
+                },
+                "phase_auto_advance": {
+                    "type": "boolean"
                 },
                 "phase_time_limit_min": {
                     "type": "integer"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -311,6 +311,11 @@ definitions:
         maximum: 9
         minimum: 1
         type: integer
+      phaseTimeLimitMin:
+        example: 10
+        maximum: 59
+        minimum: 0
+        type: integer
       retroName:
         example: sprint 10 retro
         type: string
@@ -797,6 +802,10 @@ definitions:
       ownerId:
         type: string
       phase:
+        type: string
+      phase_time_limit_min:
+        type: integer
+      phase_time_start:
         type: string
       readyUsers:
         items:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -311,6 +311,8 @@ definitions:
         maximum: 9
         minimum: 1
         type: integer
+      phaseAutoAdvance:
+        type: boolean
       phaseTimeLimitMin:
         example: 10
         maximum: 59
@@ -803,6 +805,8 @@ definitions:
         type: string
       phase:
         type: string
+      phase_auto_advance:
+        type: boolean
       phase_time_limit_min:
         type: integer
       phase_time_start:

--- a/internal/db/migrations/20240831211234_add_retro_phase_timebox.sql
+++ b/internal/db/migrations/20240831211234_add_retro_phase_timebox.sql
@@ -1,9 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE thunderdome.retro ADD COLUMN phase_time_limit_min SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE thunderdome.retro ADD COLUMN phase_auto_advance BOOLEAN NOT NULL DEFAULT false;
 ALTER TABLE thunderdome.retro ADD COLUMN phase_time_start TIMESTAMPTZ NOT NULL DEFAULT NOW();
 DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, teamid uuid);
-CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, teamid uuid)
+CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, phaseautoadvance boolean, teamid uuid)
  RETURNS uuid
  LANGUAGE plpgsql
 AS $function$
@@ -11,12 +12,12 @@ DECLARE retroId UUID;
 BEGIN
     INSERT INTO thunderdome.retro (
         owner_id, name, format, join_code, facilitator_code,
-        max_votes, brainstorm_visibility, phase_time_limit_min,
+        max_votes, brainstorm_visibility, phase_time_limit_min, phase_auto_advance,
         team_id
     )
     VALUES (
         userId, retroName, fmt, joinCode, facilitatorCode,
-        maxVotes, brainstormVisibility, phasetimelimitmin, teamid
+        maxVotes, brainstormVisibility, phasetimelimitmin, phaseautoadvance, teamid
     ) RETURNING id INTO retroId;
     INSERT INTO thunderdome.retro_facilitator (retro_id, user_id) VALUES (retroId, userId);
     INSERT INTO thunderdome.retro_user (retro_id, user_id) VALUES (retroId, userId);
@@ -30,8 +31,9 @@ $function$;
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE thunderdome.retro DROP COLUMN phase_time_limit_min;
+ALTER TABLE thunderdome.retro DROP COLUMN phase_auto_advance;
 ALTER TABLE thunderdome.retro DROP COLUMN phase_time_start;
-DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, teamid uuid);
+DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, phaseautoadvance boolean, teamid uuid);
 CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, teamid uuid)
  RETURNS uuid
  LANGUAGE plpgsql

--- a/internal/db/migrations/20240831211234_add_retro_phase_timebox.sql
+++ b/internal/db/migrations/20240831211234_add_retro_phase_timebox.sql
@@ -1,0 +1,49 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE thunderdome.retro ADD COLUMN phase_time_limit_min SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE thunderdome.retro ADD COLUMN phase_time_start TIMESTAMPTZ NOT NULL DEFAULT NOW();
+DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, teamid uuid);
+CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, teamid uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+AS $function$
+DECLARE retroId UUID;
+BEGIN
+    INSERT INTO thunderdome.retro (
+        owner_id, name, format, join_code, facilitator_code,
+        max_votes, brainstorm_visibility, phase_time_limit_min,
+        team_id
+    )
+    VALUES (
+        userId, retroName, fmt, joinCode, facilitatorCode,
+        maxVotes, brainstormVisibility, phasetimelimitmin, teamid
+    ) RETURNING id INTO retroId;
+    INSERT INTO thunderdome.retro_facilitator (retro_id, user_id) VALUES (retroId, userId);
+    INSERT INTO thunderdome.retro_user (retro_id, user_id) VALUES (retroId, userId);
+
+    RETURN retroId;
+END;
+$function$;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE thunderdome.retro DROP COLUMN phase_time_limit_min;
+ALTER TABLE thunderdome.retro DROP COLUMN phase_time_start;
+DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin int, teamid uuid);
+CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, fmt character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, teamid uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+AS $function$
+DECLARE retroId UUID;
+BEGIN
+    INSERT INTO thunderdome.retro (owner_id, name, format, join_code, facilitator_code, max_votes, brainstorm_visibility, team_id)
+    VALUES (userId, retroName, fmt, joinCode, facilitatorCode, maxVotes, brainstormVisibility, teamid) RETURNING id INTO retroId;
+    INSERT INTO thunderdome.retro_facilitator (retro_id, user_id) VALUES (retroId, userId);
+    INSERT INTO thunderdome.retro_user (retro_id, user_id) VALUES (retroId, userId);
+
+    RETURN retroId;
+END;
+$function$;
+-- +goose StatementEnd

--- a/internal/db/retro/retro.go
+++ b/internal/db/retro/retro.go
@@ -23,7 +23,7 @@ type Service struct {
 }
 
 // RetroCreate adds a new retro
-func (d *Service) RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string) (*thunderdome.Retro, error) {
+func (d *Service) RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*thunderdome.Retro, error) {
 	var encryptedJoinCode string
 	var encryptedFacilitatorCode string
 
@@ -43,11 +43,12 @@ func (d *Service) RetroCreate(OwnerID string, RetroName string, Format string, J
 		encryptedFacilitatorCode = EncryptedCode
 	}
 
-	var b = &thunderdome.Retro{
+	var retro = &thunderdome.Retro{
 		OwnerID:              OwnerID,
 		Name:                 RetroName,
 		Format:               Format,
 		Phase:                "intro",
+		PhaseTimeLimitMin:    PhaseTimeLimitMin,
 		Users:                make([]*thunderdome.RetroUser, 0),
 		Items:                make([]*thunderdome.RetroItem, 0),
 		ActionItems:          make([]*thunderdome.RetroAction, 0),
@@ -56,7 +57,7 @@ func (d *Service) RetroCreate(OwnerID string, RetroName string, Format string, J
 	}
 
 	err := d.DB.QueryRow(
-		`SELECT * FROM thunderdome.retro_create($1, $2, $3, $4, $5, $6, $7, null);`,
+		`SELECT * FROM thunderdome.retro_create($1, $2, $3, $4, $5, $6, $7, $8, null);`,
 		OwnerID,
 		RetroName,
 		Format,
@@ -64,16 +65,17 @@ func (d *Service) RetroCreate(OwnerID string, RetroName string, Format string, J
 		encryptedFacilitatorCode,
 		MaxVotes,
 		BrainstormVisibility,
-	).Scan(&b.Id)
+		PhaseTimeLimitMin,
+	).Scan(&retro.Id)
 	if err != nil {
 		return nil, fmt.Errorf("create retro query error: %v", err)
 	}
 
-	return b, nil
+	return retro, nil
 }
 
 // TeamRetroCreate adds a new retro associated to a team
-func (d *Service) TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string) (*thunderdome.Retro, error) {
+func (d *Service) TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*thunderdome.Retro, error) {
 	var encryptedJoinCode string
 	var encryptedFacilitatorCode string
 
@@ -98,6 +100,7 @@ func (d *Service) TeamRetroCreate(ctx context.Context, TeamID string, OwnerID st
 		Name:                 RetroName,
 		Format:               Format,
 		Phase:                "intro",
+		PhaseTimeLimitMin:    0,
 		Users:                make([]*thunderdome.RetroUser, 0),
 		Items:                make([]*thunderdome.RetroItem, 0),
 		ActionItems:          make([]*thunderdome.RetroAction, 0),
@@ -106,7 +109,7 @@ func (d *Service) TeamRetroCreate(ctx context.Context, TeamID string, OwnerID st
 	}
 
 	err := d.DB.QueryRowContext(ctx,
-		`SELECT * FROM thunderdome.retro_create($1, $2, $3, $4, $5, $6, $7, $8);`,
+		`SELECT * FROM thunderdome.retro_create($1, $2, $3, $4, $5, $6, $7, $8, $9);`,
 		OwnerID,
 		RetroName,
 		Format,
@@ -114,6 +117,7 @@ func (d *Service) TeamRetroCreate(ctx context.Context, TeamID string, OwnerID st
 		encryptedFacilitatorCode,
 		MaxVotes,
 		BrainstormVisibility,
+		PhaseTimeLimitMin,
 		TeamID,
 	).Scan(&b.Id)
 	if err != nil {
@@ -176,7 +180,8 @@ func (d *Service) RetroGet(RetroID string, UserID string) (*thunderdome.Retro, e
 	var ReadyUsers string
 	err := d.DB.QueryRow(
 		`SELECT
-			r.id, r.name, r.owner_id, r.format, r.phase, COALESCE(r.join_code, ''), COALESCE(r.facilitator_code, ''),
+			r.id, r.name, r.owner_id, r.format, r.phase, r.phase_time_limit_min, r.phase_time_start,
+			 COALESCE(r.join_code, ''), COALESCE(r.facilitator_code, ''),
 			r.max_votes, r.brainstorm_visibility, r.ready_users, r.created_date, r.updated_date,
 			CASE WHEN COUNT(rf) = 0 THEN '[]'::json ELSE array_to_json(array_agg(rf.user_id)) END AS facilitators
 		FROM thunderdome.retro r 
@@ -190,6 +195,8 @@ func (d *Service) RetroGet(RetroID string, UserID string) (*thunderdome.Retro, e
 		&b.OwnerID,
 		&b.Format,
 		&b.Phase,
+		&b.PhaseTimeLimitMin,
+		&b.PhaseTimeStart,
 		&JoinCode,
 		&FacilitatorCode,
 		&b.MaxVotes,
@@ -271,7 +278,7 @@ func (d *Service) RetroGetByUser(UserID string, Limit int, Offset int) ([]*thund
 		retros AS (
 			SELECT id from user_retros UNION ALL SELECT id FROM team_retros
 		)
-		SELECT r.id, r.name, r.owner_id, r.format, r.phase, r.created_date, r.updated_date,
+		SELECT r.id, r.name, r.owner_id, r.format, r.phase, r.phase_time_limit_min, r.created_date, r.updated_date,
 		  MIN(COALESCE(t.name, '')) as teamName
 		FROM thunderdome.retro r
 		LEFT JOIN user_teams t ON t.id = r.team_id
@@ -293,6 +300,7 @@ func (d *Service) RetroGetByUser(UserID string, Limit int, Offset int) ([]*thund
 			&b.OwnerID,
 			&b.Format,
 			&b.Phase,
+			&b.PhaseTimeLimitMin,
 			&b.CreatedDate,
 			&b.UpdatedDate,
 			&b.TeamName,
@@ -460,9 +468,11 @@ func (d *Service) RetroAbandon(RetroID string, UserID string) ([]*thunderdome.Re
 func (d *Service) RetroAdvancePhase(RetroID string, Phase string) (*thunderdome.Retro, error) {
 	var b thunderdome.Retro
 	err := d.DB.QueryRow(
-		`UPDATE thunderdome.retro SET updated_date = NOW(), phase = $2, ready_users = '[]'::jsonb WHERE id = $1 RETURNING name;`,
+		`UPDATE thunderdome.retro 
+			SET updated_date = NOW(), phase = $2, phase_time_start = NOW(), ready_users = '[]'::jsonb 
+			WHERE id = $1 RETURNING name, phase_time_start;`,
 		RetroID, Phase,
-	).Scan(&b.Name)
+	).Scan(&b.Name, &b.PhaseTimeStart)
 	if err != nil {
 		return nil, fmt.Errorf("retro advance phase query error: %v", err)
 	}
@@ -528,7 +538,7 @@ func (d *Service) GetRetros(Limit int, Offset int) ([]*thunderdome.Retro, int, e
 	}
 
 	rows, retrosErr := d.DB.Query(`
-		SELECT r.id, r.name, r.format, r.phase, r.created_date, r.updated_date
+		SELECT r.id, r.name, r.format, r.phase, r.phase_time_limit_min, r.created_date, r.updated_date
 		FROM thunderdome.retro r
 		GROUP BY r.id ORDER BY r.created_date DESC
 		LIMIT $1 OFFSET $2;
@@ -547,6 +557,7 @@ func (d *Service) GetRetros(Limit int, Offset int) ([]*thunderdome.Retro, int, e
 			&b.Name,
 			&b.Format,
 			&b.Phase,
+			&b.PhaseTimeLimitMin,
 			&b.CreatedDate,
 			&b.UpdatedDate,
 		); err != nil {
@@ -574,7 +585,7 @@ func (d *Service) GetActiveRetros(Limit int, Offset int) ([]*thunderdome.Retro, 
 	}
 
 	rows, retrosErr := d.DB.Query(`
-		SELECT r.id, r.name, r.format, r.phase, r.created_date, r.updated_date
+		SELECT r.id, r.name, r.format, r.phase, r.phase_time_limit_min, r.created_date, r.updated_date
 		FROM thunderdome.retro_user ru
 		LEFT JOIN thunderdome.retro r ON r.id = ru.retro_id
 		WHERE ru.active IS TRUE GROUP BY r.id
@@ -594,6 +605,7 @@ func (d *Service) GetActiveRetros(Limit int, Offset int) ([]*thunderdome.Retro, 
 			&b.Name,
 			&b.Format,
 			&b.Phase,
+			&b.PhaseTimeLimitMin,
 			&b.CreatedDate,
 			&b.UpdatedDate,
 		); err != nil {

--- a/internal/http/retro.go
+++ b/internal/http/retro.go
@@ -21,6 +21,7 @@ type retroCreateRequestBody struct {
 	FacilitatorCode      string `json:"facilitatorCode" example:"likeaboss"`
 	MaxVotes             int    `json:"maxVotes" validate:"required,min=1,max=9"`
 	BrainstormVisibility string `json:"brainstormVisibility" validate:"required,oneof=visible concealed hidden"`
+	PhaseTimeLimitMin    int    `json:"phaseTimeLimitMin" validate:"min=0,max=59" example:"10"`
 }
 
 // handleRetroCreate handles creating a retro
@@ -79,7 +80,7 @@ func (s *Service) handleRetroCreate() http.HandlerFunc {
 		// if retro created with team association
 		if teamIdExists {
 			if isTeamUserOrAnAdmin(r) {
-				newRetro, err = s.RetroDataSvc.TeamRetroCreate(ctx, TeamID, UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility)
+				newRetro, err = s.RetroDataSvc.TeamRetroCreate(ctx, TeamID, UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin)
 				if err != nil {
 					s.Logger.Ctx(ctx).Error("handleRetroCreate error", zap.Error(err), zap.String("entity_user_id", UserID),
 						zap.String("team_id", TeamID), zap.String("retro_name", nr.RetroName),
@@ -92,7 +93,7 @@ func (s *Service) handleRetroCreate() http.HandlerFunc {
 				return
 			}
 		} else {
-			newRetro, err = s.RetroDataSvc.RetroCreate(UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility)
+			newRetro, err = s.RetroDataSvc.RetroCreate(UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin)
 			if err != nil {
 				s.Logger.Ctx(ctx).Error("handleRetroCreate error", zap.Error(err), zap.String("entity_user_id", UserID),
 					zap.String("retro_name", nr.RetroName), zap.String("session_user_id", SessionUserID))

--- a/internal/http/retro.go
+++ b/internal/http/retro.go
@@ -22,6 +22,7 @@ type retroCreateRequestBody struct {
 	MaxVotes             int    `json:"maxVotes" validate:"required,min=1,max=9"`
 	BrainstormVisibility string `json:"brainstormVisibility" validate:"required,oneof=visible concealed hidden"`
 	PhaseTimeLimitMin    int    `json:"phaseTimeLimitMin" validate:"min=0,max=59" example:"10"`
+	PhaseAutoAdvance     bool   `json:"phaseAutoAdvance"`
 }
 
 // handleRetroCreate handles creating a retro
@@ -80,7 +81,7 @@ func (s *Service) handleRetroCreate() http.HandlerFunc {
 		// if retro created with team association
 		if teamIdExists {
 			if isTeamUserOrAnAdmin(r) {
-				newRetro, err = s.RetroDataSvc.TeamRetroCreate(ctx, TeamID, UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin)
+				newRetro, err = s.RetroDataSvc.TeamRetroCreate(ctx, TeamID, UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin, nr.PhaseAutoAdvance)
 				if err != nil {
 					s.Logger.Ctx(ctx).Error("handleRetroCreate error", zap.Error(err), zap.String("entity_user_id", UserID),
 						zap.String("team_id", TeamID), zap.String("retro_name", nr.RetroName),
@@ -93,7 +94,7 @@ func (s *Service) handleRetroCreate() http.HandlerFunc {
 				return
 			}
 		} else {
-			newRetro, err = s.RetroDataSvc.RetroCreate(UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin)
+			newRetro, err = s.RetroDataSvc.RetroCreate(UserID, nr.RetroName, nr.Format, nr.JoinCode, nr.FacilitatorCode, nr.MaxVotes, nr.BrainstormVisibility, nr.PhaseTimeLimitMin, nr.PhaseAutoAdvance)
 			if err != nil {
 				s.Logger.Ctx(ctx).Error("handleRetroCreate error", zap.Error(err), zap.String("entity_user_id", UserID),
 					zap.String("retro_name", nr.RetroName), zap.String("session_user_id", SessionUserID))

--- a/internal/http/retro/client.go
+++ b/internal/http/retro/client.go
@@ -30,6 +30,7 @@ var ownerOnlyOperations = map[string]struct{}{
 	"remove_facilitator": {},
 	"edit_retro":         {},
 	"concede_retro":      {},
+	"phase_time_ran_out": {},
 }
 
 // connection is a middleman between the websocket connection and the hub.

--- a/internal/http/retro/client.go
+++ b/internal/http/retro/client.go
@@ -31,6 +31,7 @@ var ownerOnlyOperations = map[string]struct{}{
 	"edit_retro":         {},
 	"concede_retro":      {},
 	"phase_time_ran_out": {},
+	"phase_all_ready":    {},
 }
 
 // connection is a middleman between the websocket connection and the hub.

--- a/internal/http/retro/events.go
+++ b/internal/http/retro/events.go
@@ -415,6 +415,7 @@ func (b *Service) EditRetro(ctx context.Context, RetroID string, UserID string, 
 		FacilitatorCode      string `json:"facilitatorCode"`
 		MaxVotes             int    `json:"maxVotes"`
 		BrainstormVisibility string `json:"brainstormVisibility"`
+		PhaseAutoAdvance     bool   `json:"phase_auto_advance"`
 	}
 	err := json.Unmarshal([]byte(EventValue), &rb)
 	if err != nil {
@@ -428,6 +429,7 @@ func (b *Service) EditRetro(ctx context.Context, RetroID string, UserID string, 
 		rb.FacilitatorCode,
 		rb.MaxVotes,
 		rb.BrainstormVisibility,
+		rb.PhaseAutoAdvance,
 	)
 	if err != nil {
 		return nil, err, false

--- a/internal/http/retro/events.go
+++ b/internal/http/retro/events.go
@@ -322,6 +322,27 @@ func (b *Service) PhaseTimeout(ctx context.Context, RetroID string, UserID strin
 	return msg, nil, false
 }
 
+// PhaseAllReady advances a retro phase after all users are ready
+func (b *Service) PhaseAllReady(ctx context.Context, RetroID string, UserID string, EventValue string) ([]byte, error, bool) {
+	var rs struct {
+		Phase string `json:"phase"`
+	}
+	err := json.Unmarshal([]byte(EventValue), &rs)
+	if err != nil {
+		return nil, err, false
+	}
+
+	retro, err := b.RetroService.RetroAdvancePhase(RetroID, rs.Phase)
+	if err != nil {
+		return nil, err, false
+	}
+
+	updatedItems, _ := json.Marshal(retro)
+	msg := createSocketEvent("phase_updated", string(updatedItems), "")
+
+	return msg, nil, false
+}
+
 // FacilitatorAdd adds a user as facilitator of the retro
 func (b *Service) FacilitatorAdd(ctx context.Context, RetroID string, UserID string, EventValue string) ([]byte, error, bool) {
 	var rs struct {

--- a/internal/http/retro/events.go
+++ b/internal/http/retro/events.go
@@ -301,6 +301,27 @@ func (b *Service) AdvancePhase(ctx context.Context, RetroID string, UserID strin
 	return msg, nil, false
 }
 
+// PhaseTimeout advances a retro phase after time countdown
+func (b *Service) PhaseTimeout(ctx context.Context, RetroID string, UserID string, EventValue string) ([]byte, error, bool) {
+	var rs struct {
+		Phase string `json:"phase"`
+	}
+	err := json.Unmarshal([]byte(EventValue), &rs)
+	if err != nil {
+		return nil, err, false
+	}
+
+	retro, err := b.RetroService.RetroAdvancePhase(RetroID, rs.Phase)
+	if err != nil {
+		return nil, err, false
+	}
+
+	updatedItems, _ := json.Marshal(retro)
+	msg := createSocketEvent("phase_updated", string(updatedItems), "")
+
+	return msg, nil, false
+}
+
 // FacilitatorAdd adds a user as facilitator of the retro
 func (b *Service) FacilitatorAdd(ctx context.Context, RetroID string, UserID string, EventValue string) ([]byte, error, bool) {
 	var rs struct {

--- a/internal/http/retro/retro.go
+++ b/internal/http/retro/retro.go
@@ -83,6 +83,7 @@ func New(
 		"action_assignee_add":    rs.ActionAddAssignee,
 		"action_assignee_remove": rs.ActionRemoveAssignee,
 		"advance_phase":          rs.AdvancePhase,
+		"phase_time_ran_out":     rs.PhaseTimeout,
 		"add_facilitator":        rs.FacilitatorAdd,
 		"remove_facilitator":     rs.FacilitatorRemove,
 		"self_facilitator":       rs.FacilitatorSelf,

--- a/internal/http/retro/retro.go
+++ b/internal/http/retro/retro.go
@@ -84,6 +84,7 @@ func New(
 		"action_assignee_remove": rs.ActionRemoveAssignee,
 		"advance_phase":          rs.AdvancePhase,
 		"phase_time_ran_out":     rs.PhaseTimeout,
+		"phase_all_ready":        rs.PhaseAllReady,
 		"add_facilitator":        rs.FacilitatorAdd,
 		"remove_facilitator":     rs.FacilitatorRemove,
 		"self_facilitator":       rs.FacilitatorSelf,

--- a/thunderdome/retro.go
+++ b/thunderdome/retro.go
@@ -1,6 +1,9 @@
 package thunderdome
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Color is a color legend
 type Color struct {
@@ -32,6 +35,8 @@ type Retro struct {
 	Facilitators         []string       `json:"facilitators"`
 	Format               string         `json:"format" db:"format"`
 	Phase                string         `json:"phase" db:"phase"`
+	PhaseTimeLimitMin    int            `json:"phase_time_limit_min" db:"phase_time_limit_min"`
+	PhaseTimeStart       time.Time      `json:"phase_time_start" db:"phase_time_start"`
 	JoinCode             string         `json:"joinCode" db:"join_code"`
 	FacilitatorCode      string         `json:"facilitatorCode" db:"facilitator_code"`
 	MaxVotes             int            `json:"maxVotes" db:"max_votes"`
@@ -83,8 +88,8 @@ type RetroVote struct {
 }
 
 type RetroDataSvc interface {
-	RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string) (*Retro, error)
-	TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string) (*Retro, error)
+	RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*Retro, error)
+	TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*Retro, error)
 	EditRetro(RetroID string, RetroName string, JoinCode string, FacilitatorCode string, maxVotes int, brainstormVisibility string) error
 	RetroGet(RetroID string, UserID string) (*Retro, error)
 	RetroGetByUser(UserID string, Limit int, Offset int) ([]*Retro, int, error)

--- a/thunderdome/retro.go
+++ b/thunderdome/retro.go
@@ -37,6 +37,7 @@ type Retro struct {
 	Phase                string         `json:"phase" db:"phase"`
 	PhaseTimeLimitMin    int            `json:"phase_time_limit_min" db:"phase_time_limit_min"`
 	PhaseTimeStart       time.Time      `json:"phase_time_start" db:"phase_time_start"`
+	PhaseAutoAdvance     bool           `json:"phase_auto_advance" db:"phase_auto_advance"`
 	JoinCode             string         `json:"joinCode" db:"join_code"`
 	FacilitatorCode      string         `json:"facilitatorCode" db:"facilitator_code"`
 	MaxVotes             int            `json:"maxVotes" db:"max_votes"`
@@ -88,9 +89,9 @@ type RetroVote struct {
 }
 
 type RetroDataSvc interface {
-	RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*Retro, error)
-	TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int) (*Retro, error)
-	EditRetro(RetroID string, RetroName string, JoinCode string, FacilitatorCode string, maxVotes int, brainstormVisibility string) error
+	RetroCreate(OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int, PhaseAutoAdvance bool) (*Retro, error)
+	TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, Format string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int, PhaseAutoAdvance bool) (*Retro, error)
+	EditRetro(RetroID string, RetroName string, JoinCode string, FacilitatorCode string, maxVotes int, brainstormVisibility string, phaseAutoAdvance bool) error
 	RetroGet(RetroID string, UserID string) (*Retro, error)
 	RetroGetByUser(UserID string, Limit int, Offset int) ([]*Retro, int, error)
 	RetroConfirmFacilitator(RetroID string, userID string) error

--- a/ui/src/components/retro/CreateRetro.svelte
+++ b/ui/src/components/retro/CreateRetro.svelte
@@ -7,6 +7,7 @@
   import LL from '../../i18n/i18n-svelte';
   import TextInput from '../forms/TextInput.svelte';
   import SelectInput from '../forms/SelectInput.svelte';
+  import Checkbox from '../forms/Checkbox.svelte';
 
   export let xfetch;
   export let notifications;
@@ -24,6 +25,7 @@
   let teams = [];
   let selectedTeam = '';
   let phaseTimeLimitMin = 0;
+  let phaseAutoAdvance = true;
 
   /** @type {TextInput} */
   let retroNameTextInput;
@@ -60,6 +62,7 @@
       maxVotes: parseInt(maxVotes, 10),
       brainstormVisibility,
       phaseTimeLimitMin: parseInt(`${phaseTimeLimitMin}`, 10),
+      phaseAutoAdvance,
     };
 
     if (selectedTeam !== '') {
@@ -246,6 +249,15 @@
         required
       />
     </div>
+  </div>
+
+  <div class="mb-4">
+    <Checkbox
+      bind:checked="{phaseAutoAdvance}"
+      id="phaseAutoAdvance"
+      name="phaseAutoAdvance"
+      label="{$LL.phaseAutoAdvanceLabel()}"
+    />
   </div>
 
   <div class="text-right">

--- a/ui/src/components/retro/CreateRetro.svelte
+++ b/ui/src/components/retro/CreateRetro.svelte
@@ -14,6 +14,8 @@
   export let router;
   export let apiPrefix = '/api';
 
+  const maxPhaseTimeLimitMin = 59;
+
   let retroName = '';
   let joinCode = '';
   let facilitatorCode = '';
@@ -21,6 +23,7 @@
   let brainstormVisibility = 'visible';
   let teams = [];
   let selectedTeam = '';
+  let phaseTimeLimitMin = 0;
 
   /** @type {TextInput} */
   let retroNameTextInput;
@@ -43,6 +46,12 @@
   function createRetro(e) {
     e.preventDefault();
     let endpoint = `${apiPrefix}/users/${$user.id}/retros`;
+
+    if (phaseTimeLimitMin > maxPhaseTimeLimitMin || phaseTimeLimitMin < 0) {
+      notifications.danger('Phase Time Limit minutes must be between 0-59');
+      return;
+    }
+
     const body = {
       retroName,
       format: 'worked_improve_question',
@@ -50,6 +59,7 @@
       facilitatorCode,
       maxVotes: parseInt(maxVotes, 10),
       brainstormVisibility,
+      phaseTimeLimitMin: parseInt(`${phaseTimeLimitMin}`, 10),
     };
 
     if (selectedTeam !== '') {
@@ -216,6 +226,26 @@
         </option>
       {/each}
     </SelectInput>
+  </div>
+
+  <div class="mb-4">
+    <label
+      class="block text-gray-700 dark:text-gray-400 text-sm font-bold mb-2"
+      for="phaseTimeLimitMin"
+    >
+      {$LL.retroPhaseTimeLimitMinLabel()}
+    </label>
+    <div class="control">
+      <TextInput
+        name="phaseTimeLimitMin"
+        bind:value="{phaseTimeLimitMin}"
+        id="phaseTimeLimitMin"
+        type="number"
+        min="0"
+        max="{maxPhaseTimeLimitMin}"
+        required
+      />
+    </div>
   </div>
 
   <div class="text-right">

--- a/ui/src/components/retro/EditRetro.svelte
+++ b/ui/src/components/retro/EditRetro.svelte
@@ -4,6 +4,7 @@
   import LL from '../../i18n/i18n-svelte';
   import TextInput from '../forms/TextInput.svelte';
   import SelectInput from '../forms/SelectInput.svelte';
+  import Checkbox from '../forms/Checkbox.svelte';
 
   export let toggleEditRetro = () => {};
   export let handleRetroEdit = () => {};
@@ -12,6 +13,7 @@
   export let facilitatorCode = '';
   export let maxVotes = '3';
   export let brainstormVisibility = 'visible';
+  export let phaseAutoAdvance = true;
 
   const brainstormVisibilityOptions = [
     {
@@ -37,6 +39,7 @@
       facilitatorCode,
       maxVotes: parseInt(maxVotes, 10),
       brainstormVisibility,
+      phase_auto_advance: phaseAutoAdvance,
     };
 
     handleRetroEdit(retro);
@@ -135,6 +138,15 @@
           </option>
         {/each}
       </SelectInput>
+    </div>
+
+    <div class="mb-4">
+      <Checkbox
+        bind:checked="{phaseAutoAdvance}"
+        id="phaseAutoAdvance"
+        name="phaseAutoAdvance"
+        label="{$LL.phaseAutoAdvanceLabel()}"
+      />
     </div>
 
     <div class="text-right">

--- a/ui/src/components/retro/PhaseTimer.svelte
+++ b/ui/src/components/retro/PhaseTimer.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy } from 'svelte';
+  import { addMinutesToDate } from '../../dateUtils';
+
+  export let retroId: string = '';
+  export let timeLimitMin: number = 0;
+  export let timeStart: Date = new Date();
+
+  const dispatch = createEventDispatcher();
+
+  let phaseEndTime = addMinutesToDate(timeStart, timeLimitMin);
+  let now: Date = new Date();
+
+  $: count = Math.round((phaseEndTime - now) / 1000);
+  $: h = Math.floor(count / 3600);
+  $: m = Math.floor((count - h * 3600) / 60);
+  $: s = count - h * 3600 - m * 60;
+
+  function updateTimer() {
+    now = new Date();
+  }
+
+  let interval = setInterval(updateTimer, 1000);
+  $: if (count === 0) {
+    clearInterval(interval);
+    dispatch('ended');
+  }
+
+  function padValue(value, length = 2, char = '0') {
+    const { length: currentLength } = value.toString();
+    if (currentLength >= length) return value.toString();
+    return `${char.repeat(length - currentLength)}${value}`;
+  }
+
+  onDestroy(() => {
+    clearInterval(interval);
+  });
+</script>
+
+<div
+  class="inline-block mr-2 font-semibold dark:text-gray-200 md:text-lg"
+  data-testid="phase-timer"
+>
+  {#each Object.entries({ m, s }) as [key, value], i}
+    <span class="mr-2">{padValue(value)}{key}</span>
+  {/each}
+</div>

--- a/ui/src/dateUtils.ts
+++ b/ui/src/dateUtils.ts
@@ -31,6 +31,12 @@ export const subtractDays = function (date, days) {
   );
 };
 
+export const addMinutesToDate = (date, n) => {
+  const d = new Date(date);
+  d.setTime(d.getTime() + n * 60000);
+  return d;
+};
+
 export const addTimeLeadZero = function (time) {
   return ('0' + time).slice(-2);
 };

--- a/ui/src/i18n/de/index.ts
+++ b/ui/src/i18n/de/index.ts
@@ -622,6 +622,7 @@ const de: Translation = {
   hideVoterIdentity: 'Identität des Schätzers verbergen',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Geben Sie einen Storyboard-Namen ein',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default de;

--- a/ui/src/i18n/de/index.ts
+++ b/ui/src/i18n/de/index.ts
@@ -623,6 +623,7 @@ const de: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Geben Sie einen Storyboard-Namen ein',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default de;

--- a/ui/src/i18n/en/index.ts
+++ b/ui/src/i18n/en/index.ts
@@ -584,6 +584,7 @@ const en: BaseTranslation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default en;

--- a/ui/src/i18n/en/index.ts
+++ b/ui/src/i18n/en/index.ts
@@ -585,6 +585,7 @@ const en: BaseTranslation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default en;

--- a/ui/src/i18n/es/index.ts
+++ b/ui/src/i18n/es/index.ts
@@ -584,6 +584,7 @@ const es: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default es;

--- a/ui/src/i18n/es/index.ts
+++ b/ui/src/i18n/es/index.ts
@@ -585,6 +585,7 @@ const es: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default es;

--- a/ui/src/i18n/fa/index.ts
+++ b/ui/src/i18n/fa/index.ts
@@ -584,6 +584,7 @@ const fa: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default fa;

--- a/ui/src/i18n/fa/index.ts
+++ b/ui/src/i18n/fa/index.ts
@@ -585,6 +585,7 @@ const fa: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default fa;

--- a/ui/src/i18n/fr/index.ts
+++ b/ui/src/i18n/fr/index.ts
@@ -593,6 +593,7 @@ const fr: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default fr;

--- a/ui/src/i18n/fr/index.ts
+++ b/ui/src/i18n/fr/index.ts
@@ -592,6 +592,7 @@ const fr: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default fr;

--- a/ui/src/i18n/it/index.ts
+++ b/ui/src/i18n/it/index.ts
@@ -612,6 +612,7 @@ const it: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default it;

--- a/ui/src/i18n/it/index.ts
+++ b/ui/src/i18n/it/index.ts
@@ -613,6 +613,7 @@ const it: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default it;

--- a/ui/src/i18n/pt/index.ts
+++ b/ui/src/i18n/pt/index.ts
@@ -600,6 +600,7 @@ const pt: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default pt;

--- a/ui/src/i18n/pt/index.ts
+++ b/ui/src/i18n/pt/index.ts
@@ -601,6 +601,7 @@ const pt: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default pt;

--- a/ui/src/i18n/ru/index.ts
+++ b/ui/src/i18n/ru/index.ts
@@ -584,6 +584,7 @@ const ru: Translation = {
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
   retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
+  phaseAutoAdvanceLabel: 'Automatically advance phases',
 };
 
 export default ru;

--- a/ui/src/i18n/ru/index.ts
+++ b/ui/src/i18n/ru/index.ts
@@ -583,6 +583,7 @@ const ru: Translation = {
   hideVoterIdentity: 'Hide Voter Identity',
   storyboardName: 'Storyboard Name',
   storyboardNamePlaceholder: 'Enter a storyboard name',
+  retroPhaseTimeLimitMinLabel: 'Brainstorm Phase time limit in minutes',
 };
 
 export default ru;

--- a/ui/src/pages/retro/Retro.svelte
+++ b/ui/src/pages/retro/Retro.svelte
@@ -46,6 +46,7 @@
     phase: 'brainstorm',
     phase_time_limit_min: 0,
     phase_time_start: new Date(),
+    phase_auto_advance: false,
     users: [],
     items: [],
     groups: [],
@@ -145,10 +146,6 @@
         notifications.danger(`${leftUser.name} left.`);
         break;
       }
-      case 'retro_updated':
-        retro = JSON.parse(parsedEvent.value);
-        groupedItems = organizeItemsByGroup();
-        break;
       case 'phase_updated':
         let r = JSON.parse(parsedEvent.value);
         retro.items = r.items;
@@ -239,6 +236,7 @@
         retro.joinCode = revisedRetro.joinCode;
         retro.brainstormVisibility = revisedRetro.brainstormVisibility;
         retro.maxVotes = revisedRetro.maxVotes;
+        retro.phase_auto_advance = revisedRetro.phase_auto_advance;
         break;
       case 'conceded':
         // retro over, goodbye.
@@ -546,7 +544,12 @@
     const activeUsers = retro.users.filter(u => u.active);
     let allReady = retro.readyUsers.length === activeUsers.length;
 
-    if (isFacilitator && retro.phase === 'brainstorm' && allReady) {
+    if (
+      isFacilitator &&
+      retro.phase_auto_advance &&
+      retro.phase === 'brainstorm' &&
+      allReady
+    ) {
       sendSocketEvent(
         'phase_all_ready',
         JSON.stringify({
@@ -1039,6 +1042,7 @@
     facilitatorCode="{retro.facilitatorCode}"
     maxVotes="{retro.maxVotes}"
     brainstormVisibility="{retro.brainstormVisibility}"
+    phaseAutoAdvance="{retro.phase_auto_advance}"
   />
 {/if}
 

--- a/ui/src/pages/retro/Retro.svelte
+++ b/ui/src/pages/retro/Retro.svelte
@@ -158,6 +158,7 @@
         retro.phase = r.phase;
         retro.phase_time_start = new Date(r.phase_time_start);
         retro.phase_time_limit_min = r.phase_time_limit_min;
+        retro.readyUsers = [];
         phaseTimeStart = new Date(r.phase_time_start);
 
         groupedItems = organizeItemsByGroup();
@@ -173,7 +174,7 @@
       case 'user_marked_ready': {
         const readyUser = retro.users.find(w => w.id === parsedEvent.userId);
         retro.readyUsers = JSON.parse(parsedEvent.value);
-
+        phaseReadyCheck();
         notifications.success(`${readyUser.name} is done brainstorming.`);
         break;
       }
@@ -538,6 +539,21 @@
         }),
       );
       eventTag('phase_time_ran_out', 'retro', '');
+    }
+  }
+
+  function phaseReadyCheck() {
+    const activeUsers = retro.users.filter(u => u.active);
+    let allReady = retro.readyUsers.length === activeUsers.length;
+
+    if (isFacilitator && retro.phase === 'brainstorm' && allReady) {
+      sendSocketEvent(
+        'phase_all_ready',
+        JSON.stringify({
+          phase: 'group',
+        }),
+      );
+      eventTag('phase_all_ready', 'retro', '');
     }
   }
 


### PR DESCRIPTION
## Description

Add timer to retro feature brainstorm phase
Also adds auto advance phases option that will automatically advance the brainstorm phase when all active users of the retro are marked ready.

This resolves #525 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots/Recordings

<img width="256" alt="image" src="https://github.com/user-attachments/assets/4f09ce95-3256-45fd-ae7f-2b908f6db2aa">

## Steps to QA

QA Timer
1. Create a retro and set the time limit in minutes to a number between 1-59 to enable the timer
2. Advance to brainstorm phase
3. Once the timer reaches 0 the brainstorm phase will automatically end and advance

QA Auto Advance
1. Create a retro with auto advance phases enabled
2. Advance to brainstorm phase
3. Mark oneself ready, once all active users of the retro are ready the phase will automatically advance
<!-- note: PRs with deleted sections will be marked invalid -->