### PR TITLE
Add cumulative voting option to retros defaulting to false

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -9137,6 +9137,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/{userId}/teams-non-org": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get a list of teams the user is a part of that are not associated with an organization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "team"
+                ],
+                "summary": "Get User Teams Non Org",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "the user ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/http.standardJsonResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/thunderdome.UserTeam"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/http.standardJsonResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/{orgId}/departments/{departmentId}/teams/{teamId}/users/{userId}/battles": {
             "post": {
                 "security": [
@@ -10153,6 +10208,9 @@ const docTemplate = `{
                 "retroName"
             ],
             "properties": {
+                "allowCumulativeVoting": {
+                    "type": "boolean"
+                },
                 "brainstormVisibility": {
                     "type": "string",
                     "enum": [
@@ -11014,6 +11072,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/thunderdome.RetroAction"
                     }
                 },
+                "allowCumulativeVoting": {
+                    "type": "boolean"
+                },
                 "brainstormVisibility": {
                     "type": "string"
                 },
@@ -11301,6 +11362,9 @@ const docTemplate = `{
         "thunderdome.RetroVote": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
                 "groupId": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -9129,6 +9129,61 @@
                 }
             }
         },
+        "/users/{userId}/teams-non-org": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get a list of teams the user is a part of that are not associated with an organization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "team"
+                ],
+                "summary": "Get User Teams Non Org",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "the user ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/http.standardJsonResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/thunderdome.UserTeam"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/http.standardJsonResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/{orgId}/departments/{departmentId}/teams/{teamId}/users/{userId}/battles": {
             "post": {
                 "security": [
@@ -10145,6 +10200,9 @@
                 "retroName"
             ],
             "properties": {
+                "allowCumulativeVoting": {
+                    "type": "boolean"
+                },
                 "brainstormVisibility": {
                     "type": "string",
                     "enum": [
@@ -11006,6 +11064,9 @@
                         "$ref": "#/definitions/thunderdome.RetroAction"
                     }
                 },
+                "allowCumulativeVoting": {
+                    "type": "boolean"
+                },
                 "brainstormVisibility": {
                     "type": "string"
                 },
@@ -11293,6 +11354,9 @@
         "thunderdome.RetroVote": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
                 "groupId": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -350,6 +350,8 @@ definitions:
     type: object
   http.retroCreateRequestBody:
     properties:
+      allowCumulativeVoting:
+        type: boolean
       brainstormVisibility:
         enum:
         - visible
@@ -932,6 +934,8 @@ definitions:
         items:
           $ref: '#/definitions/thunderdome.RetroAction'
         type: array
+      allowCumulativeVoting:
+        type: boolean
       brainstormVisibility:
         type: string
       createdDate:
@@ -1120,6 +1124,8 @@ definitions:
     type: object
   thunderdome.RetroVote:
     properties:
+      count:
+        type: integer
       groupId:
         type: string
       userId:
@@ -7429,6 +7435,39 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Create Team
+      tags:
+      - team
+  /users/{userId}/teams-non-org:
+    get:
+      description: Get a list of teams the user is a part of that are not associated
+        with an organization
+      parameters:
+      - description: the user ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/http.standardJsonResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/thunderdome.UserTeam'
+                  type: array
+              type: object
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/http.standardJsonResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get User Teams Non Org
       tags:
       - team
 securityDefinitions:

--- a/internal/db/migrations/20240913020848_add_retro_vote_stacking.sql
+++ b/internal/db/migrations/20240913020848_add_retro_vote_stacking.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add vote_count column to the existing table
+ALTER TABLE "thunderdome"."retro_group_vote"
+ADD COLUMN "vote_count" integer NOT NULL DEFAULT 1;
+
+-- Create an index on vote_count for performance
+CREATE INDEX "idx_retro_group_vote_vote_count"
+ON "thunderdome"."retro_group_vote" ("vote_count");
+
+-- Add allow_cumulative_voting column to the existing table
+ALTER TABLE "thunderdome"."retro"
+ADD COLUMN "allow_cumulative_voting" boolean NOT NULL DEFAULT false;
+
+DROP FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin integer, phaseautoadvance boolean, teamid uuid, templateid uuid);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Drop allow_cumulative_voting column from the table
+ALTER TABLE "thunderdome"."retro" DROP COLUMN "allow_cumulative_voting";
+
+-- Drop vote_count column from the table
+ALTER TABLE "thunderdome"."retro_group_vote"
+DROP COLUMN "vote_count";
+
+CREATE OR REPLACE FUNCTION thunderdome.retro_create(userid uuid, retroname character varying, joincode text, facilitatorcode text, maxvotes smallint, brainstormvisibility character varying, phasetimelimitmin integer, phaseautoadvance boolean, teamid uuid, templateid uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+AS $function$
+DECLARE retroId UUID;
+BEGIN
+    INSERT INTO thunderdome.retro (
+        owner_id, name, join_code, facilitator_code,
+        max_votes, brainstorm_visibility, phase_time_limit_min, phase_auto_advance,
+        team_id, template_id
+    )
+    VALUES (
+        userId, retroName, joinCode, facilitatorCode,
+        maxVotes, brainstormVisibility, phasetimelimitmin, phaseautoadvance, teamid, templateid
+    ) RETURNING id INTO retroId;
+
+    INSERT INTO thunderdome.retro_facilitator (retro_id, user_id) VALUES (retroId, userId);
+    INSERT INTO thunderdome.retro_user (retro_id, user_id) VALUES (retroId, userId);
+
+    RETURN retroId;
+END;
+$function$;
+
+-- +goose StatementEnd

--- a/internal/db/poker/poker.go
+++ b/internal/db/poker/poker.go
@@ -67,6 +67,8 @@ func (d *Service) CreateGame(ctx context.Context, FacilitatorID string, Name str
 		d.Logger.Error("create poker error", zap.Error(err))
 	}
 
+	defer tx.Rollback()
+
 	// Insert into poker table
 	err = tx.QueryRowContext(ctx, `
             INSERT INTO thunderdome.poker 
@@ -78,9 +80,6 @@ func (d *Service) CreateGame(ctx context.Context, FacilitatorID string, Name str
 		PointAverageRounding, HideVoterIdentity, encryptedJoinCode, encryptedLeaderCode,
 	).Scan(&b.Id)
 	if err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			d.Logger.Error("update drivers: unable to rollback", zap.Error(rollbackErr))
-		}
 		d.Logger.Error("create poker error", zap.Error(err))
 		return nil, fmt.Errorf("failed to insert into poker table: %v", err)
 	}
@@ -91,9 +90,6 @@ func (d *Service) CreateGame(ctx context.Context, FacilitatorID string, Name str
             VALUES ($1, $2)
         `, &b.Id, FacilitatorID)
 	if err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			d.Logger.Error("update drivers: unable to rollback", zap.Error(rollbackErr))
-		}
 		d.Logger.Error("create poker error", zap.Error(err))
 		return nil, fmt.Errorf("failed to insert into poker_facilitator table: %v", err)
 	}
@@ -104,9 +100,6 @@ func (d *Service) CreateGame(ctx context.Context, FacilitatorID string, Name str
             VALUES ($1, $2)
         `, &b.Id, FacilitatorID)
 	if err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			d.Logger.Error("update drivers: unable to rollback", zap.Error(rollbackErr))
-		}
 		d.Logger.Error("create poker error", zap.Error(err))
 		return nil, fmt.Errorf("failed to insert into poker_user table: %v", err)
 	}

--- a/internal/db/retro/vote.go
+++ b/internal/db/retro/vote.go
@@ -1,0 +1,252 @@
+package retro
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/StevenWeathers/thunderdome-planning-poker/thunderdome"
+	"go.uber.org/zap"
+)
+
+type VoteLimitExceededError struct{}
+
+func (e *VoteLimitExceededError) Error() string {
+	return "Vote limit exceeded for this retro"
+}
+
+type VoteAlreadyCastError struct{}
+
+func (e *VoteAlreadyCastError) Error() string {
+	return "Vote already cast for this group and cumulative voting is not allowed"
+}
+
+type UnauthorizedUserError struct{}
+
+func (e *UnauthorizedUserError) Error() string {
+	return "User is not authorized to vote in this retro"
+}
+
+type VotePhaseNotActiveError struct{}
+
+func (e *VotePhaseNotActiveError) Error() string {
+	return "Vote phase has ended or has not started yet for this retro"
+}
+
+// Helper function to check if a user is authorized for a retro
+func isUserAuthorizedForRetro(tx *sql.Tx, RetroID, UserID string) (bool, error) {
+	var active bool
+	err := tx.QueryRow(`
+		SELECT COALESCE((SELECT coalesce(active, FALSE)
+		FROM thunderdome.retro_user
+		WHERE user_id = $2 AND retro_id = $1), FALSE);`,
+		RetroID,
+		UserID,
+	).Scan(
+		&active,
+	)
+	if err != nil {
+		return false, fmt.Errorf("get retro user active status query error: %v", err)
+	}
+
+	return active, nil
+}
+
+// GroupUserVote inserts a user vote for the retro item group
+func (d *Service) GroupUserVote(RetroID string, GroupID string, UserID string) ([]*thunderdome.RetroVote, error) {
+	var allowCumulativeVoting bool
+	var phase string
+	var maxVotes int
+	var totalVoteCount int
+	var groupVoteCount int
+	type voteGroup struct {
+		RetroID   string `json:"retro_id"`
+		GroupID   string `json:"group_id"`
+		UserID    string `json:"user_id"`
+		VoteCount int    `json:"vote_count"`
+	}
+	var votesString string
+	voteGroups := make([]voteGroup, 0)
+
+	// Start a transaction
+	tx, err := d.DB.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() // Rollback if not committed
+
+	// First, check if the user is authorized to vote in this retro
+	authorized, err := isUserAuthorizedForRetro(tx, RetroID, UserID)
+	if err != nil {
+		d.Logger.Error("error checking user authorization", zap.Error(err))
+		return nil, fmt.Errorf("error checking user authorization: %w", err)
+	}
+	if !authorized {
+		return nil, &UnauthorizedUserError{}
+	}
+
+	err = tx.QueryRow(
+		`SELECT r.max_votes, r.allow_cumulative_voting, r.phase,
+				COALESCE((SELECT jsonb_agg(rgv)
+				FROM thunderdome.retro_group_vote rgv
+				WHERE rgv.retro_id = $1 AND rgv.user_id = $2 LIMIT 1), '[]'::jsonb) as votes
+				FROM thunderdome.retro r
+				WHERE r.id = $1;`,
+		RetroID, UserID,
+	).Scan(&maxVotes, &allowCumulativeVoting, &phase, &votesString)
+	if err != nil {
+		d.Logger.Error("retro vote query error", zap.Error(err))
+		return nil, err
+	}
+
+	if phase != "vote" {
+		return nil, &VotePhaseNotActiveError{}
+	}
+
+	err = json.Unmarshal([]byte(votesString), &voteGroups)
+	if err != nil {
+		d.Logger.Error("retro vote json error", zap.Error(err))
+		return nil, err
+	}
+
+	for _, vg := range voteGroups {
+		totalVoteCount += vg.VoteCount
+		if vg.GroupID == GroupID {
+			groupVoteCount = vg.VoteCount
+		}
+	}
+
+	if totalVoteCount >= maxVotes {
+		return nil, &VoteLimitExceededError{}
+	}
+
+	if groupVoteCount > 0 && !allowCumulativeVoting {
+		return nil, &VoteAlreadyCastError{}
+	}
+
+	result, err := tx.Exec(
+		`INSERT INTO thunderdome.retro_group_vote (retro_id, group_id, user_id, vote_count)
+				VALUES ($1, $2, $3, 1)
+				ON CONFLICT (retro_id, group_id, user_id)
+				DO UPDATE SET vote_count = thunderdome.retro_group_vote.vote_count + 1
+				WHERE thunderdome.retro_group_vote.retro_id = $1
+				  AND thunderdome.retro_group_vote.group_id = $2
+				  AND thunderdome.retro_group_vote.user_id = $3
+				  AND EXISTS (
+					SELECT 1
+					FROM thunderdome.retro
+					WHERE id = $1 AND allow_cumulative_voting = true
+  			);`,
+		RetroID, GroupID, UserID,
+	)
+	if err != nil {
+		d.Logger.Error("retro group vote query error", zap.Error(err))
+		return nil, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		d.Logger.Error("retro group vote rows affected error", zap.Error(err))
+		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		d.Logger.Error("retro group vote rows affected zero error", zap.Error(err))
+		return nil, fmt.Errorf("no vote found to retract")
+	}
+
+	// Commit the transaction
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	votes := d.GetRetroVotes(RetroID)
+
+	return votes, nil
+}
+
+// GroupUserSubtractVote retracts a single user vote for the retro item group
+func (d *Service) GroupUserSubtractVote(RetroID string, GroupID string, UserID string) ([]*thunderdome.RetroVote, error) {
+	// Start a transaction
+	tx, err := d.DB.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() // Rollback if not committed
+
+	// Check if cumulative voting is enabled and get the current vote count
+	var allowCumulativeVoting bool
+	var currentVoteCount int
+	err = tx.QueryRow(`
+        SELECT r.allow_cumulative_voting, COALESCE(rgv.vote_count, 0)
+        FROM thunderdome.retro r
+        LEFT JOIN thunderdome.retro_group_vote rgv ON r.id = rgv.retro_id AND rgv.group_id = $2 AND rgv.user_id = $3
+        WHERE r.id = $1
+    `, RetroID, GroupID, UserID).Scan(&allowCumulativeVoting, &currentVoteCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get retro and vote information: %w", err)
+	}
+
+	if currentVoteCount == 0 {
+		return nil, fmt.Errorf("no vote found to retract")
+	}
+
+	var result sql.Result
+	if allowCumulativeVoting && currentVoteCount > 1 {
+		// Decrement the vote count if cumulative voting is enabled and there's more than one vote
+		result, err = tx.Exec(`
+            UPDATE thunderdome.retro_group_vote
+            SET vote_count = vote_count - 1
+            WHERE retro_id = $1 AND group_id = $2 AND user_id = $3;
+        `, RetroID, GroupID, UserID)
+	} else {
+		// Delete the vote if it's the last one or cumulative voting is not enabled
+		result, err = tx.Exec(`
+            DELETE FROM thunderdome.retro_group_vote
+            WHERE retro_id = $1 AND group_id = $2 AND user_id = $3;
+        `, RetroID, GroupID, UserID)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to update vote: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return nil, fmt.Errorf("no vote found to retract")
+	}
+
+	// Commit the transaction
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	votes := d.GetRetroVotes(RetroID)
+	return votes, nil
+}
+
+// GetRetroVotes gets retro votes
+func (d *Service) GetRetroVotes(RetroID string) []*thunderdome.RetroVote {
+	var votes = make([]*thunderdome.RetroVote, 0)
+
+	itemRows, itemsErr := d.DB.Query(
+		`SELECT group_id, user_id, vote_count FROM thunderdome.retro_group_vote WHERE retro_id = $1;`,
+		RetroID,
+	)
+	if itemsErr == nil {
+		defer itemRows.Close()
+		for itemRows.Next() {
+			var rv = &thunderdome.RetroVote{}
+			if err := itemRows.Scan(&rv.GroupID, &rv.UserID, &rv.Count); err != nil {
+				d.Logger.Error("get retro votes query scan error", zap.Error(err))
+			} else {
+				votes = append(votes, rv)
+			}
+		}
+	} else {
+		d.Logger.Error("get retro votes query error", zap.Error(itemsErr))
+	}
+
+	return votes
+}

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -133,6 +133,7 @@ func New(apiService Service, FSS fs.FS, HFS http.FileSystem) *Service {
 	userRouter.HandleFunc("/{userId}/organizations", a.userOnly(a.entityUserOnly(a.handleCreateOrganization()))).Methods("POST")
 	userRouter.HandleFunc("/{userId}/teams", a.userOnly(a.entityUserOnly(a.handleGetTeamsByUser()))).Methods("GET")
 	userRouter.HandleFunc("/{userId}/teams", a.userOnly(a.entityUserOnly(a.handleCreateTeam()))).Methods("POST")
+	userRouter.HandleFunc("/{userId}/teams-non-org", a.userOnly(a.entityUserOnly(a.handleGetTeamsByUserNonOrg()))).Methods("GET")
 	if a.Config.SubscriptionsEnabled {
 		userRouter.HandleFunc("/{userId}/subscriptions", a.userOnly(a.entityUserOnly(a.handleGetEntityUserActiveSubs()))).Methods("GET")
 		userRouter.HandleFunc("/{userId}/subscriptions/{subscriptionId}", a.userOnly(a.entityUserOnly(a.handleEntityUserUpdateSubscription()))).Methods("PATCH")

--- a/internal/http/team.go
+++ b/internal/http/team.go
@@ -81,6 +81,30 @@ func (s *Service) handleGetTeamsByUser() http.HandlerFunc {
 	}
 }
 
+// handleGetTeamsByUser gets a list of teams the user is a part of that are not associated with an organization
+// @Summary      Get User Teams Non Org
+// @Description  Get a list of teams the user is a part of that are not associated with an organization
+// @Tags         team
+// @Produce      json
+// @Param        userId  path    string  true  "the user ID"
+// @Success      200     object  standardJsonResponse{data=[]thunderdome.UserTeam}
+// @Success      403     object  standardJsonResponse{}
+// @Security     ApiKeyAuth
+// @Router       /users/{userId}/teams-non-org [get]
+func (s *Service) handleGetTeamsByUserNonOrg() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+		UserID := vars["userId"]
+
+		Limit, Offset := getLimitOffsetFromRequest(r)
+
+		Teams := s.TeamDataSvc.TeamListByUserNonOrg(ctx, UserID, Limit, Offset)
+
+		s.Success(w, r, http.StatusOK, Teams, nil)
+	}
+}
+
 // handleGetTeamUsers gets a list of users associated to the team
 // @Summary      Get Team users
 // @Description  Get a list of users associated to the team

--- a/thunderdome/retro.go
+++ b/thunderdome/retro.go
@@ -24,29 +24,30 @@ type RetroUser struct {
 
 // Retro A story mapping board
 type Retro struct {
-	Id                   string         `json:"id" db:"id"`
-	OwnerID              string         `json:"ownerId" db:"owner_id"`
-	Name                 string         `json:"name" db:"name"`
-	TemplateID           string         `json:"template_id" db:"template_id"`
-	Users                []*RetroUser   `json:"users"`
-	Groups               []*RetroGroup  `json:"groups"`
-	Items                []*RetroItem   `json:"items"`
-	ActionItems          []*RetroAction `json:"actionItems"`
-	Votes                []*RetroVote   `json:"votes"`
-	ReadyUsers           []string       `json:"readyUsers"`
-	Facilitators         []string       `json:"facilitators"`
-	Phase                string         `json:"phase" db:"phase"`
-	PhaseTimeLimitMin    int            `json:"phase_time_limit_min" db:"phase_time_limit_min"`
-	PhaseTimeStart       time.Time      `json:"phase_time_start" db:"phase_time_start"`
-	PhaseAutoAdvance     bool           `json:"phase_auto_advance" db:"phase_auto_advance"`
-	JoinCode             string         `json:"joinCode" db:"join_code"`
-	FacilitatorCode      string         `json:"facilitatorCode" db:"facilitator_code"`
-	MaxVotes             int            `json:"maxVotes" db:"max_votes"`
-	BrainstormVisibility string         `json:"brainstormVisibility" db:"brainstorm_visibility"`
-	Template             RetroTemplate  `json:"template"`
-	TeamName             string         `json:"teamName"`
-	CreatedDate          string         `json:"createdDate" db:"created_date"`
-	UpdatedDate          string         `json:"updatedDate" db:"updated_date"`
+	Id                    string         `json:"id" db:"id"`
+	OwnerID               string         `json:"ownerId" db:"owner_id"`
+	Name                  string         `json:"name" db:"name"`
+	TemplateID            string         `json:"template_id" db:"template_id"`
+	Users                 []*RetroUser   `json:"users"`
+	Groups                []*RetroGroup  `json:"groups"`
+	Items                 []*RetroItem   `json:"items"`
+	ActionItems           []*RetroAction `json:"actionItems"`
+	Votes                 []*RetroVote   `json:"votes"`
+	ReadyUsers            []string       `json:"readyUsers"`
+	Facilitators          []string       `json:"facilitators"`
+	Phase                 string         `json:"phase" db:"phase"`
+	PhaseTimeLimitMin     int            `json:"phase_time_limit_min" db:"phase_time_limit_min"`
+	PhaseTimeStart        time.Time      `json:"phase_time_start" db:"phase_time_start"`
+	PhaseAutoAdvance      bool           `json:"phase_auto_advance" db:"phase_auto_advance"`
+	JoinCode              string         `json:"joinCode" db:"join_code"`
+	FacilitatorCode       string         `json:"facilitatorCode" db:"facilitator_code"`
+	MaxVotes              int            `json:"maxVotes" db:"max_votes"`
+	BrainstormVisibility  string         `json:"brainstormVisibility" db:"brainstorm_visibility"`
+	AllowCumulativeVoting bool           `json:"allowCumulativeVoting" db:"allow_cumulative_voting"`
+	Template              RetroTemplate  `json:"template"`
+	TeamName              string         `json:"teamName"`
+	CreatedDate           string         `json:"createdDate" db:"created_date"`
+	UpdatedDate           string         `json:"updatedDate" db:"updated_date"`
 }
 
 // RetroItem can be a pro (went well/worked), con (needs improvement), or a question
@@ -99,11 +100,11 @@ type RetroItemComment struct {
 type RetroVote struct {
 	UserID  string `json:"userId" db:"user_id"`
 	GroupID string `json:"groupId" db:"group_id"`
+	Count   int    `json:"count" db:"vote_count"`
 }
 
 type RetroDataSvc interface {
-	RetroCreate(OwnerID string, RetroName string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int, PhaseAutoAdvance bool, TemplateID string) (*Retro, error)
-	TeamRetroCreate(ctx context.Context, TeamID string, OwnerID string, RetroName string, JoinCode string, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int, PhaseAutoAdvance bool, TemplateID string) (*Retro, error)
+	CreateRetro(ctx context.Context, OwnerID, TeamID string, RetroName, JoinCode, FacilitatorCode string, MaxVotes int, BrainstormVisibility string, PhaseTimeLimitMin int, PhaseAutoAdvance bool, AllowCumulativeVoting bool, TemplateID string) (*Retro, error)
 	EditRetro(RetroID string, RetroName string, JoinCode string, FacilitatorCode string, maxVotes int, brainstormVisibility string, phaseAutoAdvance bool) error
 	RetroGet(RetroID string, UserID string) (*Retro, error)
 	RetroGetByUser(UserID string, Limit int, Offset int) ([]*Retro, int, error)

--- a/thunderdome/team.go
+++ b/thunderdome/team.go
@@ -60,6 +60,7 @@ type TeamDataSvc interface {
 	TeamUserRole(ctx context.Context, UserID string, TeamID string) (string, error)
 	TeamGet(ctx context.Context, TeamID string) (*Team, error)
 	TeamListByUser(ctx context.Context, UserID string, Limit int, Offset int) []*UserTeam
+	TeamListByUserNonOrg(ctx context.Context, UserID string, Limit int, Offset int) []*UserTeam
 	TeamCreate(ctx context.Context, UserID string, TeamName string) (*Team, error)
 	TeamUpdate(ctx context.Context, TeamId string, TeamName string) (*Team, error)
 	TeamAddUser(ctx context.Context, TeamID string, UserID string, Role string) (string, error)

--- a/ui/src/components/retro/CreateRetro.svelte
+++ b/ui/src/components/retro/CreateRetro.svelte
@@ -28,6 +28,7 @@
   let phaseTimeLimitMin = 0;
   let templateId = '';
   let phaseAutoAdvance = true;
+  let allowCumulativeVoting = false;
   let publicTemplates = [];
 
   /** @type {TextInput} */
@@ -65,6 +66,7 @@
       brainstormVisibility,
       phaseTimeLimitMin: parseInt(`${phaseTimeLimitMin}`, 10),
       phaseAutoAdvance,
+      allowCumulativeVoting,
       templateId,
     };
 
@@ -244,6 +246,15 @@
         required
       />
     </div>
+  </div>
+
+  <div class="mb-4">
+    <Checkbox
+      bind:checked="{allowCumulativeVoting}"
+      id="allowCumulativeVoting"
+      name="allowCumulativeVoting"
+      label="{$LL.allowCumulativeVotingLabel()}"
+    />
   </div>
 
   <div class="mb-4">

--- a/ui/src/components/retro/GroupedItems.svelte
+++ b/ui/src/components/retro/GroupedItems.svelte
@@ -21,7 +21,7 @@
         <div class="flex content-center justify-center">
           <div class="inline-block align-middle text-2xl ms-2">
             <ThumbsUp class="w-6 h-6 inline-block" />
-            {group.votes.length}
+            {group.voteCount}
           </div>
         </div>
         {group.name ? group.name : 'Group'}

--- a/ui/src/components/retro/UserCard.svelte
+++ b/ui/src/components/retro/UserCard.svelte
@@ -15,8 +15,19 @@
   export let handleUserReady = () => {};
   export let handleUserUnReady = () => {};
 
-  $: reachedMaxVotes =
-    votes && votes.filter(v => v.userId === user.id).length === maxVotes;
+  $: voteTally =
+    votes &&
+    votes.reduce(
+      (p, v) => {
+        if (v.userId === user.id) {
+          p.votesLeft -= v.count;
+          p.userVoteCount += v.count;
+        }
+
+        return p;
+      },
+      { userVoteCount: 0, votesLeft: maxVotes },
+    );
 
   $: userReady = readyUsers && readyUsers.includes(user.id);
 </script>
@@ -86,13 +97,13 @@
       {/if}
     {/if}
     {#if phase === 'vote'}
-      {#if reachedMaxVotes}
+      {#if voteTally.userVoteCount >= maxVotes}
         <div class="text-lime-500 dark:text-lime-400">
           {$LL.allVotesIn()}
         </div>
       {:else}
         <div class="text-blue-600 dark:text-blue-400">
-          {maxVotes - votes.filter(v => v.userId === user.id).length} votes left
+          {voteTally.votesLeft} votes left
         </div>
       {/if}
     {/if}

--- a/ui/src/components/retro/VotePhase.svelte
+++ b/ui/src/components/retro/VotePhase.svelte
@@ -7,11 +7,14 @@
   export let handleVoteSubtract = () => {};
   export let voteLimitReached = false;
   export let columns = [];
+  export let allowCumulativeVoting: boolean = false;
 
   const handleVoteAction = group => {
-    const alreadyVoted = group.votes.includes($user.id);
-
-    if (alreadyVoted) {
+    const userVoted = group.votes.find(v => v.userId === $user.id);
+    if (
+      (userVoted && !allowCumulativeVoting) ||
+      (allowCumulativeVoting && voteLimitReached)
+    ) {
       handleVoteSubtract(group.id);
     } else {
       handleVote(group.id);
@@ -54,7 +57,7 @@
             <ThumbsUp class="w-6 h-6 inline-block" />
           </button>
           <div class="inline-block align-middle text-2xl ms-2">
-            {group.votes.length}
+            {group.voteCount}
           </div>
         </div>
         {group.name ? group.name : 'Group'}

--- a/ui/src/i18n/de/index.ts
+++ b/ui/src/i18n/de/index.ts
@@ -666,6 +666,8 @@ const de: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default de;

--- a/ui/src/i18n/en/index.ts
+++ b/ui/src/i18n/en/index.ts
@@ -628,6 +628,8 @@ const en: BaseTranslation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default en;

--- a/ui/src/i18n/es/index.ts
+++ b/ui/src/i18n/es/index.ts
@@ -628,6 +628,8 @@ const es: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default es;

--- a/ui/src/i18n/fa/index.ts
+++ b/ui/src/i18n/fa/index.ts
@@ -628,6 +628,8 @@ const fa: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default fa;

--- a/ui/src/i18n/fr/index.ts
+++ b/ui/src/i18n/fr/index.ts
@@ -636,6 +636,8 @@ const fr: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default fr;

--- a/ui/src/i18n/it/index.ts
+++ b/ui/src/i18n/it/index.ts
@@ -656,6 +656,8 @@ const it: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default it;

--- a/ui/src/i18n/pt/index.ts
+++ b/ui/src/i18n/pt/index.ts
@@ -644,6 +644,8 @@ const pt: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default pt;

--- a/ui/src/i18n/ru/index.ts
+++ b/ui/src/i18n/ru/index.ts
@@ -627,6 +627,8 @@ const ru: Translation = {
   publicEstimationScales: 'Public Estimation Scales',
   organizationEstimationScales: 'Organization Estimation Scales',
   teamEstimationScales: 'Team Estimation Scales',
+  allowCumulativeVotingLabel:
+    'Allow Cumulative Voting (more than 1 vote per item group)',
 };
 
 export default ru;

--- a/ui/src/pages/retro/Retro.svelte
+++ b/ui/src/pages/retro/Retro.svelte
@@ -69,6 +69,7 @@
         columns: [],
       },
     },
+    allowCumulativeVoting: false,
   };
   let showDeleteRetro = false;
   let actionItem = '';
@@ -88,6 +89,7 @@
         name: g.name,
         items: [],
         votes: [],
+        voteCount: 0,
         userVoted: false,
       };
       return prev;
@@ -102,10 +104,12 @@
     });
 
     retro.votes.map(vote => {
-      ++voteCount;
-      groupMap[vote.groupId].votes.push(vote.userId);
+      voteCount = voteCount + vote.count;
+      groupMap[vote.groupId].voteCount =
+        groupMap[vote.groupId].voteCount + vote.count;
+      groupMap[vote.groupId].votes.push(vote);
       if (vote.userId === $user.id) {
-        ++userVoteCount;
+        userVoteCount = userVoteCount + vote.count;
         groupMap[vote.groupId].userVoted = true;
       }
     });
@@ -117,7 +121,7 @@
     result = Object.values(groupMap);
     if (retro.phase === 'action' || retro.phase === 'completed') {
       result.sort((a, b) => {
-        return b.votes.length - a.votes.length;
+        return b.voteCount - a.voteCount;
       });
     }
     if (retro.phase === 'vote') {
@@ -811,6 +815,7 @@
                 handleVoteSubtract="{handleVoteSubtract}"
                 voteLimitReached="{voteLimitReached}"
                 columns="{retro.template.format.columns}"
+                allowCumulativeVoting="{retro.allowCumulativeVoting}"
               />
             </div>
           </div>

--- a/ui/src/pages/team/Teams.svelte
+++ b/ui/src/pages/team/Teams.svelte
@@ -79,7 +79,7 @@
   function getTeams() {
     const teamsOffset = (teamsPage - 1) * teamsPageLimit;
     xfetch(
-      `/api/users/${$user.id}/teams?limit=${teamsPageLimit}&offset=${teamsOffset}`,
+      `/api/users/${$user.id}/teams-non-org?limit=${teamsPageLimit}&offset=${teamsOffset}`,
     )
       .then(res => res.json())
       .then(function (result) {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This PR adds cumulative voting option to retros (defaulting to false) allowing users to vote more than once on an item group.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

This resolves #614 

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->