### PR TITLE
style: poker stories plans text and buttons align

### DIFF
--- a/ui/src/components/poker/PokerStories.svelte
+++ b/ui/src/components/poker/PokerStories.svelte
@@ -326,49 +326,46 @@
       </div>
       {#if plan[SHADOW_ITEM_MARKER_PROPERTY_NAME]}
         <div
-          class="opacity-50 absolute top-0 left-0 right-0 bottom-0 visible opacity-50 cursor-pointer flex flex-wrap items-center border-b border-gray-300 dark:border-gray-700 p-4 bg-white dark:bg-gray-800"
+          class="opacity-50 absolute top-0 left-0 right-0 bottom-0 visible opacity-50 cursor-pointer flex items-center border-b border-gray-300 dark:border-gray-700 p-4 bg-white dark:bg-gray-800"
           data-testid="plan"
           data-storyid="{plan.id}"
         >
-          <div class="w-full lg:w-1/3 mb-4 lg:mb-0">
-            <div class="inline-block font-bold align-middle dark:text-white">
-              {#if plan.link !== ''}
-                <a
-                  href="{plan.link}"
-                  target="_blank"
-                  class="text-blue-800 dark:text-sky-400"
-                >
-                  <ExternalLink class="inline-block" />
-                </a>
-                &nbsp;
-              {/if}
-              <div
-                class="inline-block text-sm text-gray-500 dark:text-gray-300
-                        border-gray-300 border px-1 rounded"
-                data-testid="plan-type"
+          <div class="flex-grow font-bold align-middle dark:text-white">
+            {#if plan.link !== ''}
+              <a
+                href="{plan.link}"
+                target="_blank"
+                class="text-blue-800 dark:text-sky-400"
               >
-                {plan.type}
-              </div>
+                <ExternalLink class="inline-block" />
+              </a>
               &nbsp;
-              {#if plan.referenceId}[{plan.referenceId}]&nbsp;{/if}
-              <svelte:component
-                this="{priorities[plan.priority].icon}"
-                class="inline-block w-6 h-6"
-              />
-              <span data-testid="plan-name">{plan.name}</span>
+            {/if}
+            <div
+              class="inline-block text-sm text-gray-500 dark:text-gray-300
+                        border-gray-300 border px-1 rounded"
+              data-testid="plan-type"
+            >
+              {plan.type}
             </div>
             &nbsp;
+            {#if plan.referenceId}[{plan.referenceId}]&nbsp;{/if}
+            <svelte:component
+              this="{priorities[plan.priority].icon}"
+              class="inline-block w-6 h-6"
+            />
+            <span data-testid="plan-name">{plan.name}</span>
+          </div>
+          <div class="lg:flex-none text-right">
             {#if plan.points !== ''}
               <div
                 class="inline-block font-bold text-green-600 dark:text-lime-400
-                        border-green-500 dark:border-lime-400 border px-2 py-1 rounded ms-2"
+                        border-green-500 dark:border-lime-400 border px-2 py-1 rounded me-1"
                 data-testid="plan-points"
               >
                 {plan.points}
               </div>
             {/if}
-          </div>
-          <div class="w-full lg:w-2/3 text-right">
             <HollowButton
               color="blue"
               onClick="{togglePlanView(plan.id)}"

--- a/ui/src/components/poker/PokerStories.svelte
+++ b/ui/src/components/poker/PokerStories.svelte
@@ -243,7 +243,7 @@
   >
     {#each plans as plan (plan.id)}
       <div
-        class="relative flex flex-wrap items-center border-b border-gray-300 dark:border-gray-700 p-4 bg-white dark:bg-gray-800{isLeader &&
+        class="relative flex items-center border-b border-gray-300 dark:border-gray-700 p-4 bg-white dark:bg-gray-800{isLeader &&
         storysShow === 'all'
           ? ' cursor-pointer'
           : ''}{(plan.points === '' && storysShow === 'pointed') ||
@@ -253,44 +253,42 @@
         data-testid="plan"
         data-storyid="{plan.id}"
       >
-        <div class="w-full lg:w-1/3 mb-4 lg:mb-0">
-          <div class="inline-block font-bold align-middle dark:text-white mr-1">
-            {#if plan.link !== ''}
-              <a
-                href="{plan.link}"
-                target="_blank"
-                class="text-blue-800 dark:text-sky-400"
-              >
-                <ExternalLink class="inline-block" />
-              </a>
-              &nbsp;
-            {/if}
-            <div
-              class="inline-block text-sm text-gray-500 dark:text-gray-300
-                        border-gray-300 border px-1 rounded"
-              data-testid="plan-type"
+        <div class="flex-grow font-bold align-middle dark:text-white mr-1">
+          {#if plan.link !== ''}
+            <a
+              href="{plan.link}"
+              target="_blank"
+              class="text-blue-800 dark:text-sky-400"
             >
-              {plan.type}
-            </div>
+              <ExternalLink class="inline-block" />
+            </a>
             &nbsp;
-            {#if plan.referenceId}[{plan.referenceId}]&nbsp;{/if}
-            <svelte:component
-              this="{priorities[plan.priority].icon}"
-              class="inline-block w-6 h-6"
-            />
-            <span data-testid="plan-name">{plan.name}</span>
+          {/if}
+          <div
+            class="inline-block text-sm text-gray-500 dark:text-gray-300
+                      border-gray-300 border px-1 rounded"
+            data-testid="plan-type"
+          >
+            {plan.type}
           </div>
+          &nbsp;
+          {#if plan.referenceId}[{plan.referenceId}]&nbsp;{/if}
+          <svelte:component
+            this="{priorities[plan.priority].icon}"
+            class="inline-block w-6 h-6"
+          />
+          <span data-testid="plan-name">{plan.name}</span>
+        </div>
+        <div class="lg:flex-none text-right">
           {#if plan.points !== ''}
             <div
               class="inline-block font-bold text-green-600 dark:text-lime-400
-                        border-green-500 dark:border-lime-400 border px-2 py-1 rounded ms-2"
+                        border-green-500 dark:border-lime-400 border px-2 py-1 rounded me-1"
               data-testid="plan-points"
             >
               {plan.points}
             </div>
           {/if}
-        </div>
-        <div class="w-full lg:w-2/3 text-right">
           <HollowButton
             color="blue"
             onClick="{togglePlanView(plan.id)}"


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR replaces the style of the Poker Stories page to ensure the alignment of action buttons on each line of the story list, as illustrated in the attached screenshot.

Details:
- Enhances visual consistency by aligning buttons across all rows.
- Optimizes the use of available space, providing more width pixels for story text.

Basically, these changes improve both the aesthetics and readability of the page.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [X] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Before:
![thunderdome_before_pc](https://github.com/user-attachments/assets/446560c9-445c-4c60-a081-41d25995d344)

### After:
![thunderdome_after_pc](https://github.com/user-attachments/assets/f44a4167-06a5-456a-b9be-a29610062b87)
