### PR TITLE
CSP fix + omit Google Analytics if analytics is disabled.

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -50,7 +50,7 @@ func New(apiService Service, FSS fs.FS, HFS http.FileSystem) *Service {
 	// Content Security Policy
 	cspBuilder := cspbuilder.Builder{
 		Directives: map[string][]string{
-			cspbuilder.DefaultSrc: {"self", fmt.Sprintf("*.%s", a.Config.AppDomain)},
+			cspbuilder.DefaultSrc: {"'self'", fmt.Sprintf("*.%s", a.Config.AppDomain)},
 			//	@TODO	- remove inline styles in svelte components to improve security by using nonce
 			cspbuilder.StyleSrc:  {"'self'", "'unsafe-inline'", "https://fonts.googleapis.com"},
 			cspbuilder.ScriptSrc: {"$NONCE"},


### PR DESCRIPTION
## Description

This PR fixes the CSP directive for `default-src`, which used to contain `self` (note the lack of quotes) which gets interpreted by browsers as the _hostname_ `self`. By adding quotes (`'self'`), this is fixed.

I believe the lack of quotes caused the user's selected theme not to be applied (but I'm not quite sure _why_, as the `<script>` adding the theme's class has a `nonce`).

Additionally, the `connect-src` CSP directive used to _always_ include Google Analytics, even with analytics disabled. This PR also omits the Google Analytics hosts when analytics is disabled.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert