### PR TITLE
Fix oidc flow upsert for user, sub doesnt always match email

### DIFF
--- a/internal/db/auth/oauth.go
+++ b/internal/db/auth/oauth.go
@@ -159,7 +159,7 @@ func (d *Service) OauthUpsertUser(ctx context.Context, provider string, sub stri
  				 COALESCE(u.locale, ''), u.disabled, u.theme, COALESCE(u.picture, '')
  				 FROM thunderdome.users u
  				 WHERE u.email = $1;`,
-			sub,
+			email,
 		).Scan(
 			&user.ID,
 			&user.Name,


### PR DESCRIPTION
## Description

This PR attempts to fix #679 by upserting user based on email not sub when falling back to existing users. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

Likely a fix for #679 

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->