### PR TITLE
Add removal of accents in username for email address TO header

### DIFF
--- a/internal/email/util.go
+++ b/internal/email/util.go
@@ -2,8 +2,12 @@ package email
 
 import (
 	"fmt"
+	"unicode"
 
 	"github.com/StevenWeathers/thunderdome-planning-poker/thunderdome"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 // formatRetroItemForMarkdownList formats a retro item for a markdown list
@@ -25,4 +29,14 @@ func formatRetroActionWithAssignee(action *thunderdome.RetroAction) string {
 	}
 
 	return formatRetroItemForMarkdownList(actionItem)
+}
+
+// removeAccents removes accents from a string
+func removeAccents(s string) (string, error) {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	output, _, e := transform.String(t, s)
+	if e != nil {
+		return "", e
+	}
+	return output, nil
 }

--- a/internal/email/util_test.go
+++ b/internal/email/util_test.go
@@ -59,13 +59,12 @@ func TestRemoveAccents(t *testing.T) {
 			expected: "nino, jalapeno",
 			err:      false,
 		},
-		// Test 9: Handling an invalid error case (although unlikely)
+		// Test 9: Handling an invalid byte sequence
 		{
-			// Here we are assuming there might be some edge case or failure.
-			// For now, we expect no errors unless transform implementation changes.
-			input:    string([]byte{0x80}), // Invalid byte sequence
-			expected: "",
-			err:      true,
+			// Input with an invalid byte sequence (0x80 is not valid UTF-8)
+			input:    string([]byte{0x80}),
+			expected: "�",   // The replacement character that Go uses for invalid UTF-8 sequences
+			err:      false, // No error is expected, just replacement
 		},
 	}
 

--- a/internal/email/util_test.go
+++ b/internal/email/util_test.go
@@ -1,0 +1,92 @@
+package email
+
+import (
+	"testing"
+)
+
+// Test for removeAccents function
+func TestRemoveAccents(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		err      bool
+	}{
+		// Test 1: String without accents
+		{
+			input:    "hello",
+			expected: "hello",
+			err:      false,
+		},
+		// Test 2: String with accents (common case)
+		{
+			input:    "héllo",
+			expected: "hello",
+			err:      false,
+		},
+		// Test 3: String with multiple accents
+		{
+			input:    "façade",
+			expected: "facade",
+			err:      false,
+		},
+		// Test 4: String with combined accented characters
+		{
+			input:    "café",
+			expected: "cafe",
+			err:      false,
+		},
+		// Test 5: Empty string
+		{
+			input:    "",
+			expected: "",
+			err:      false,
+		},
+		// Test 6: String with only non-accented characters
+		{
+			input:    "hello world!",
+			expected: "hello world!",
+			err:      false,
+		},
+		// Test 7: String with special characters (no accents)
+		{
+			input:    "123!@#$",
+			expected: "123!@#$",
+			err:      false,
+		},
+		// Test 8: String with a mix of accented and non-accented characters
+		{
+			input:    "niño, jalapeño",
+			expected: "nino, jalapeno",
+			err:      false,
+		},
+		// Test 9: Handling an invalid error case (although unlikely)
+		{
+			// Here we are assuming there might be some edge case or failure.
+			// For now, we expect no errors unless transform implementation changes.
+			input:    string([]byte{0x80}), // Invalid byte sequence
+			expected: "",
+			err:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			output, err := removeAccents(test.input)
+
+			// Check if we expect an error
+			if test.err && err == nil {
+				t.Errorf("expected error, but got nil")
+			}
+
+			// Check if we don't expect an error
+			if !test.err && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Check the output
+			if output != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add removal of accents in username for email address TO header.
Also add error handling on invalid address headers instead of ignoring them and attempting to send.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

#662 potentially fixes this issue if the username containing accents is the root cause

## Screenshots/Recordings
![Screenshot 2025-03-28 112358](https://github.com/user-attachments/assets/d6667319-033d-453b-91de-83ab3bed65c0)

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->