### PR TITLE
Change 2fa field name for password manager support

### DIFF
--- a/ui/src/components/auth/LoginForm.svelte
+++ b/ui/src/components/auth/LoginForm.svelte
@@ -332,7 +332,7 @@
         bind:value={mfaToken}
         placeholder="Enter code"
         id="mfaToken"
-        name="mfaToken"
+        name="twofactor_token"
         required
         icon={Shield}
         inputmode="numeric"

--- a/ui/src/components/user/SetupMFA.svelte
+++ b/ui/src/components/user/SetupMFA.svelte
@@ -84,7 +84,7 @@
           bind:value="{passcode}"
           placeholder={$LL.mfaTokenPlaceholder()}
           id="mfaPasscode"
-          name="mfaPasscode"
+          name="twofactor_token"
           type="password"
           required
           icon={Shield}


### PR DESCRIPTION
## Description

Change 2fa field name for password manager support

(Still need to test this, basing the field name off a working example with a popular password manager, would like to test with others to confirm)

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->