### PR TITLE
Fix for team checkin link path to support prefix

### DIFF
--- a/ui/src/pages/Dashboard.svelte
+++ b/ui/src/pages/Dashboard.svelte
@@ -263,10 +263,10 @@
             </div>
             {#if selectedTeam}
               {@const linkPrefix = selectedTeam.department_id
-                ? `/organization/${selectedTeam.organization_id}/department/${selectedTeam.department_id}/team/${selectedTeam.id}`
+                ? `${AppConfig.PathPrefix}/organization/${selectedTeam.organization_id}/department/${selectedTeam.department_id}/team/${selectedTeam.id}`
                 : selectedTeam.organization_id
-                  ? `/organization/${selectedTeam.organization_id}/team/${selectedTeam.id}`
-                  : `/team/${selectedTeam.id}`}
+                  ? `${AppConfig.PathPrefix}/organization/${selectedTeam.organization_id}/team/${selectedTeam.id}`
+                  : `${AppConfig.PathPrefix}/team/${selectedTeam.id}`}
               <div class="flex flex-col sm:flex-row gap-3 mt-4 justify-end">
                 <a
                   href={linkPrefix}

--- a/ui/src/pages/team/Team.svelte
+++ b/ui/src/pages/team/Team.svelte
@@ -113,7 +113,7 @@
 
   let currentPageUrl = $derived(
     teamPrefix
-      .replace('/api', '')
+      .replace('/api/', '')
       .replace('organizations', 'organization')
       .replace('departments', 'department')
       .replace('teams', 'team'),
@@ -493,7 +493,9 @@
       {/if}
     </div>
     <div class="flex-1 text-right">
-      <SolidButton additionalClasses="font-rajdhani uppercase text-2xl" href={`${currentPageUrl}/checkin`}
+      <SolidButton
+        additionalClasses="font-rajdhani uppercase text-2xl"
+        href={`${AppConfig.PathPrefix}/${currentPageUrl}/checkin`}
         >{$LL.checkins()}
       </SolidButton>
     </div>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This fixes #825 by using PathPrefix on Team Checkin links

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #825 

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->