### PR TITLE
fixes wrong rounding (N/A) in case someone votes 1/2

### DIFF
--- a/ui/src/components/poker/VotingMetrics.svelte
+++ b/ui/src/components/poker/VotingMetrics.svelte
@@ -64,7 +64,7 @@
     if (isNumeric) {
       const numericVotes = votes
         .filter(v => !isNaN(v.vote) || v.vote === '1/2')
-        .map(v => (v === '1/2' ? '0.5' : Number(v.vote)));
+        .map(v => (v.vote === '1/2' ? 0.5 : Number(v.vote)));
       const sum = numericVotes.reduce((a, b) => a + b, 0);
       let average = 0;
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

This PR fixes a bug when at least one Person votes 1/2 resulting in a N/A average result.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

Vote for 1/2. Should not result in a N/A anymore.

<!-- note: PRs with deleted sections will be marked invalid -->