### PR TITLE
Change Retro Item Inputs to Textarea

### DIFF
--- a/ui/src/components/global/GrowingTextArea.svelte
+++ b/ui/src/components/global/GrowingTextArea.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  interface Props {
+    value?: string;
+    placeholder?: string;
+    id?: string;
+    name?: string;
+    required?: boolean;
+    class?: string;
+    onkeydown?: (e: KeyboardEvent) => void;
+  }
+
+  let {
+    value = $bindable(''),
+    placeholder = '',
+    id = '',
+    name = '',
+    required = false,
+    class: className = '',
+    onkeydown,
+  }: Props = $props();
+
+  let textareaElement: HTMLTextAreaElement;
+  let initialHeight = 0;
+
+  $effect(() => {
+    // Watch value and recalculate height when it changes
+    value;
+    recalculateHeight();
+  });
+
+  const handleInput = (e: Event) => {
+    const target = e.currentTarget as HTMLTextAreaElement;
+    if (initialHeight === 0) {
+      initialHeight = target.offsetHeight;
+    }
+    target.style.height = 'auto';
+    const newHeight = Math.max(initialHeight, target.scrollHeight);
+    target.style.height = newHeight + 'px';
+  };
+
+  const resetHeight = () => {
+    if (textareaElement) {
+      textareaElement.style.height = '';
+      initialHeight = 0;
+    }
+  };
+
+  const recalculateHeight = () => {
+    if (textareaElement) {
+      if (initialHeight === 0) {
+        initialHeight = textareaElement.offsetHeight;
+      }
+      textareaElement.style.height = 'auto';
+      const newHeight = Math.max(initialHeight, textareaElement.scrollHeight);
+      textareaElement.style.height = newHeight + 'px';
+    }
+  };
+
+  const focus = () => {
+    textareaElement?.focus();
+  };
+
+  export { resetHeight, focus };
+</script>
+
+<textarea
+  bind:this={textareaElement}
+  bind:value
+  {placeholder}
+  {id}
+  {name}
+  {required}
+  rows="1"
+  class="dark:bg-gray-800 border-gray-300 dark:border-gray-700 border-2 appearance-none rounded py-2
+            px-3 text-gray-700 dark:text-gray-400 leading-tight focus:outline-none
+            focus:bg-white dark:focus:bg-gray-700 focus:border-indigo-500 dark:focus:border-yellow-400 w-full resize-none overflow-hidden box-border {className}"
+  oninput={handleInput}
+  {onkeydown}
+></textarea>

--- a/ui/src/components/retro/ActionComments.svelte
+++ b/ui/src/components/retro/ActionComments.svelte
@@ -133,7 +133,7 @@
             </div>
           </div>
         {:else}
-          <div class="py-2">
+          <div class="py-2 whitespace-pre-wrap break-words">
             {comment.comment}
           </div>
         {/if}

--- a/ui/src/components/retro/BrainstormPhase.svelte
+++ b/ui/src/components/retro/BrainstormPhase.svelte
@@ -8,7 +8,7 @@
     items?: any;
     template?: any;
     users?: any;
-    brainstormVisibility?: boolean;
+    brainstormVisibility?: string;
     columnColors?: any;
   }
 
@@ -23,7 +23,7 @@
       },
     },
     users = [],
-    brainstormVisibility = false,
+    brainstormVisibility = 'visible',
     columnColors = {},
   }: Props = $props();
 

--- a/ui/src/components/retro/EditActionItem.svelte
+++ b/ui/src/components/retro/EditActionItem.svelte
@@ -6,6 +6,7 @@
   import UserAvatar from '../user/UserAvatar.svelte';
   import SelectInput from '../forms/SelectInput.svelte';
   import Checkbox from '../forms/Checkbox.svelte';
+  import GrowingTextArea from '../global/GrowingTextArea.svelte';
   import { Trash2 } from '@lucide/svelte';
   import { onMount } from 'svelte';
 
@@ -44,6 +45,8 @@
     completed: false,
   });
 
+  let textareaComponent: any;
+
   $effect(() => {
     editAction.id = action.id;
     editAction.retroId = action.retroId;
@@ -56,14 +59,14 @@
 
     handleEdit(editAction);
   };
+
   const addAssignee = () => {
     handleAssigneeAdd(action.retroId, action.id, selectedAssignee);
     selectedAssignee = '';
   };
 
-  let focusInput: any;
   onMount(() => {
-    focusInput?.focus();
+    textareaComponent?.focus();
   });
 </script>
 
@@ -74,16 +77,12 @@
         {$LL.actionItem()}
       </label>
       <div class="control">
-        <input
+        <GrowingTextArea
+          bind:this={textareaComponent}
           bind:value={editAction.content}
-          bind:this={focusInput}
           placeholder={$LL.actionItemPlaceholder()}
-          class="dark:bg-gray-800 border-gray-300 dark:border-gray-700 border-2 appearance-none rounded py-2
-                px-3 text-gray-700 dark:text-gray-400 leading-tight focus:outline-none
-                focus:bg-white dark:focus:bg-gray-700 focus:border-indigo-500 dark:focus:border-yellow-400 w-full"
           id="actionItem"
           name="actionItem"
-          type="text"
           required
         />
       </div>

--- a/ui/src/components/retro/ItemForm.svelte
+++ b/ui/src/components/retro/ItemForm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Angry, CircleHelp, Frown, Smile } from '@lucide/svelte';
+  import { Angry, CircleQuestionMark, Frown, Smile } from '@lucide/svelte';
+  import GrowingTextArea from '../global/GrowingTextArea.svelte';
   import RetroFeedbackItem from './RetroFeedbackItem.svelte';
+  import type { RetroItem, RetroUser } from '../../types/retro';
 
   interface Props {
     sendSocketEvent?: any;
@@ -9,8 +11,8 @@
     newItemPlaceholder?: string;
     phase?: string;
     isFacilitator?: boolean;
-    items?: any;
-    users?: any;
+    items?: RetroItem[];
+    users?: RetroUser[];
     feedbackVisibility?: string;
     icon?: string;
     color?: string;
@@ -32,6 +34,8 @@
     columnColors = {},
   }: Props = $props();
 
+  let textareaComponent: any;
+
   const handleFormSubmit = (evt: Event) => {
     evt.preventDefault();
 
@@ -44,14 +48,15 @@
       }),
     );
     content = '';
+    textareaComponent?.resetHeight();
   };
 </script>
 
 <div class="p-3 bg-white dark:bg-gray-800 rounded-lg shadow-lg flex flex-col flex-wrap text-gray-800 dark:text-white">
-  <div class="flex items-center mb-4">
+  <div class="flex items-start mb-4">
     {#if icon !== ''}
       <div
-        class="flex-shrink pe-2"
+        class="flex-shrink pt-1 pe-2"
         class:text-green-400={color === 'green'}
         class:dark:text-lime-400={color === 'green'}
         class:text-red-500={color === 'red'}
@@ -71,30 +76,33 @@
         {:else if icon === 'frown'}
           <Frown class="w-8 h-8" />
         {:else if icon === 'question'}
-          <CircleHelp class="w-8 h-8" />
+          <CircleQuestionMark class="w-8 h-8" />
         {:else if icon === 'angry'}
           <Angry class="w-8 h-8" />
         {/if}
       </div>
     {/if}
     <div class="flex-grow">
-      <form onsubmit={handleFormSubmit} class="flex">
-        <input
+      <form onsubmit={handleFormSubmit} class="flex flex-col w-full min-w-0">
+        <GrowingTextArea
+          bind:this={textareaComponent}
           bind:value={content}
           placeholder={newItemPlaceholder}
-          class="dark:bg-gray-800 border-gray-300 dark:border-gray-700 border-2 appearance-none rounded py-2
-                    px-3 text-gray-700 dark:text-gray-400 leading-tight focus:outline-none
-                    focus:bg-white dark:focus:bg-gray-700 focus:border-indigo-500 dark:focus:border-yellow-400 w-full"
           id="new{itemType}"
           name="new{itemType}"
-          type="text"
           required
+          onkeydown={(e: KeyboardEvent) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleFormSubmit(e as unknown as Event);
+            }
+          }}
         />
         <button type="submit" class="hidden">submit</button>
       </form>
     </div>
   </div>
-  <div>
+  <div class="min-w-0">
     {#each items.filter(i => i.type === itemType) as item}
       <RetroFeedbackItem {item} {phase} {users} {isFacilitator} {sendSocketEvent} {columnColors} {feedbackVisibility} />
     {/each}

--- a/ui/src/components/retro/RetroActionForm.svelte
+++ b/ui/src/components/retro/RetroActionForm.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import GrowingTextArea from '../global/GrowingTextArea.svelte';
+  import { SquareCheckBig } from '@lucide/svelte';
+  import LL from '../../i18n/i18n-svelte';
+
+  interface Props {
+    onsubmit?: (content: string) => void;
+  }
+
+  let { onsubmit }: Props = $props();
+
+  let actionItem = $state('');
+  let textareaComponent: any;
+  let formElement: HTMLFormElement;
+
+  const handleSubmit = (evt: Event) => {
+    evt.preventDefault();
+    if (actionItem.trim()) {
+      onsubmit?.(actionItem);
+      actionItem = '';
+      textareaComponent?.resetHeight();
+    }
+  };
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      formElement?.requestSubmit();
+    }
+  };
+</script>
+
+<div class="flex items-start mb-4">
+  <div class="flex-shrink pe-2 pt-1">
+    <SquareCheckBig class="w-8 h-8 text-indigo-500 dark:text-violet-400" />
+  </div>
+  <div class="flex-grow">
+    <form bind:this={formElement} onsubmit={handleSubmit}>
+      <GrowingTextArea
+        bind:this={textareaComponent}
+        bind:value={actionItem}
+        placeholder={$LL.actionItemPlaceholder()}
+        id="actionItem"
+        name="actionItem"
+        required
+        onkeydown={handleKeydown}
+      />
+      <button type="submit" class="hidden">submit</button>
+    </form>
+  </div>
+</div>

--- a/ui/src/components/retro/RetroActionItemReview.svelte
+++ b/ui/src/components/retro/RetroActionItemReview.svelte
@@ -17,6 +17,7 @@
 
   import type { NotificationService } from '../../types/notifications';
   import type { ApiClient } from '../../types/apiclient';
+  import type { RetroAction } from '../../types/retro';
 
   interface Props {
     xfetch: ApiClient;
@@ -47,7 +48,7 @@
 
   let totalRetroActions = $state(0);
   let retroActionsPage = $state(1);
-  let actionItems = $state([]);
+  let actionItems: RetroAction[] = $state([]);
   let users = $state([]);
   let usersPage = 1;
 
@@ -69,20 +70,20 @@
   }
 
   let showRetroActionComments = $state(false);
-  let selectedRetroAction = $state(null);
-  const toggleRetroActionComments = (id: string) => () => {
+  let selectedRetroAction = $state<RetroAction | null>(null);
+  const toggleRetroActionComments = (id: string | null) => () => {
     showRetroActionComments = !showRetroActionComments;
-    selectedRetroAction = id;
+    selectedRetroAction = id !== null ? (actionItems.find(r => r.id === id) ?? null) : null;
   };
 
   let showRetroActionEdit = $state(false);
-  let selectedAction: string | null = $state(null);
+  let selectedAction: RetroAction | null = $state(null);
   const toggleRetroActionEdit = (retroId: string | null, id: string | null) => () => {
     showRetroActionEdit = !showRetroActionEdit;
     selectedAction = retroId !== null ? (actionItems.find(r => r.id === id) ?? null) : null;
   };
 
-  function handleRetroActionEdit(action) {
+  function handleRetroActionEdit(action: RetroAction) {
     xfetch(`/api/retros/${action.retroId}/actions/${action.id}`, {
       method: 'PUT',
       body: {
@@ -100,7 +101,7 @@
       });
   }
 
-  function handleRetroActionDelete(action) {
+  function handleRetroActionDelete(action: RetroAction) {
     return () => {
       xfetch(`/api/retros/${action.retroId}/actions/${action.id}`, {
         method: 'DELETE',
@@ -193,7 +194,7 @@
                         width={24}
                         class="inline-block me-2"
                       />
-                    {/each}{item.content}
+                    {/each}<span class="whitespace-pre-wrap break-words">{item.content}</span>
                   </div>
                 </RowCol>
                 <RowCol>

--- a/ui/src/components/retro/RetroFeedbackItem.svelte
+++ b/ui/src/components/retro/RetroFeedbackItem.svelte
@@ -3,6 +3,7 @@
   import ItemComments from './ItemComments.svelte';
   import { user } from '../../stores';
   import LL from '../../i18n/i18n-svelte';
+  import type { RetroItem } from '../../types/retro';
 
   interface Props {
     class?: string;
@@ -34,9 +35,9 @@
   }: Props = $props();
 
   let showComments = $state(false);
-  let selectedItem = $state(null);
+  let selectedItem = $state<RetroItem | null>(null);
 
-  const toggleComments = item => () => {
+  const toggleComments = (item: RetroItem | null) => () => {
     showComments = !showComments;
     selectedItem = item;
   };
@@ -110,7 +111,7 @@
       </button>
     {/if}
   </div>
-  <p data-testid="retro-feedback-item-content">
+  <p data-testid="retro-feedback-item-content" class="whitespace-pre-wrap break-words">
     {#if phase === 'brainstorm' && feedbackVisibility === 'hidden' && item.userId !== $user.id}
       <span class="italic">{$LL.retroFeedbackHidden()}</span>
     {:else if phase === 'brainstorm' && feedbackVisibility === 'concealed' && item.userId !== $user.id}

--- a/ui/src/pages/retro/Retro.svelte
+++ b/ui/src/pages/retro/Retro.svelte
@@ -2,17 +2,7 @@
   import Sockette from 'sockette';
   import { onDestroy, onMount } from 'svelte';
   import HollowButton from '../../components/global/HollowButton.svelte';
-  import {
-    Check,
-    ChevronRight,
-    Crown,
-    ExternalLink,
-    LogOut,
-    Pencil,
-    Settings,
-    SquareCheckBig,
-    Trash,
-  } from '@lucide/svelte';
+  import { Check, ChevronRight, Crown, ExternalLink, LogOut, Pencil, Settings, Trash } from '@lucide/svelte';
   import DeleteConfirmation from '../../components/global/DeleteConfirmation.svelte';
   import SolidButton from '../../components/global/SolidButton.svelte';
   import EditRetro from '../../components/retro/EditRetro.svelte';
@@ -25,6 +15,7 @@
   import GroupPhase from '../../components/retro/GroupPhase.svelte';
   import VotePhase from '../../components/retro/VotePhase.svelte';
   import GroupedItems from '../../components/retro/GroupedItems.svelte';
+  import RetroActionForm from '../../components/retro/RetroActionForm.svelte';
   import UserCard from '../../components/retro/UserCard.svelte';
   import InviteUser from '../../components/retro/InviteUser.svelte';
   import UserAvatar from '../../components/user/UserAvatar.svelte';
@@ -89,7 +80,6 @@
     hideVotesDuringVoting: false,
   });
   let showDeleteRetro = $state(false);
-  let actionItem = $state('');
   let showExport = $state(false);
   let groupedItems = $state([]);
   let JoinPassRequired = $state(false);
@@ -411,16 +401,13 @@
     );
   };
 
-  const handleActionItem = (evt: Event) => {
-    evt.preventDefault();
-
+  const handleActionItem = (content: string) => {
     sendSocketEvent(
       'create_action',
       JSON.stringify({
-        content: actionItem,
+        content,
       }),
     );
-    actionItem = '';
   };
 
   const handleActionUpdate = (id: string, completed: boolean, content: string) => () => {
@@ -865,33 +852,13 @@
           <div class="w-full md:w-1/3">
             <div class="ps-4">
               {#if retro.phase === 'action'}
-                <div class="flex items-center mb-4">
-                  <div class="flex-shrink pe-2">
-                    <SquareCheckBig class="w-8 h-8 text-indigo-500 dark:text-violet-400" />
-                  </div>
-                  <div class="flex-grow">
-                    <form onsubmit={handleActionItem}>
-                      <input
-                        bind:value={actionItem}
-                        placeholder={$LL.actionItemPlaceholder()}
-                        class="dark:bg-gray-800 border-gray-300 dark:border-gray-700 border-2 appearance-none rounded py-2
-                    px-3 text-gray-700 dark:text-gray-400 leading-tight focus:outline-none
-                    focus:bg-white dark:focus:bg-gray-700 focus:border-indigo-500 dark:focus:border-yellow-400 w-full"
-                        id="actionItem"
-                        name="actionItem"
-                        type="text"
-                        required
-                      />
-                      <button type="submit" class="hidden">submit</button>
-                    </form>
-                  </div>
-                </div>
+                <RetroActionForm onsubmit={handleActionItem} />
               {/if}
               {#each retro.actionItems as item, i}
                 <div
                   class="mb-2 p-2 bg-white dark:bg-gray-800 shadow border-s-4 border-indigo-500 dark:border-violet-400"
                 >
-                  <div class="flex items-center">
+                  <div class="flex items-start">
                     <div class="flex-shrink">
                       <button
                         onclick={toggleActionEdit(item.id)}
@@ -913,10 +880,10 @@
                             class="inline-block me-2"
                           />
                         {/each}
-                        {item.content}
+                        <span class="whitespace-pre-wrap break-words">{item.content}</span>
                       </div>
                     </div>
-                    <div class="flex-shrink">
+                    <div class="flex-shrink pt-1">
                       <input
                         type="checkbox"
                         id="{i}Completed"


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

Changes retro feedback and action item inputs to textarea that grows with typing and displays multi line break

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

Resolves #810 by changing retro feedback and action item inputs to textarea that grows with typing and displays multi line break

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->