### PR TITLE
Add Retro Item Emoji reactions

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -16897,6 +16897,12 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "reactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/thunderdome.RetroItemReaction"
+                    }
+                },
                 "type": {
                     "type": "string"
                 },
@@ -16918,6 +16924,29 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "item_id": {
+                    "type": "string"
+                },
+                "updated_date": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "thunderdome.RetroItemReaction": {
+            "type": "object",
+            "properties": {
+                "created_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "item_id": {
+                    "type": "string"
+                },
+                "reaction": {
                     "type": "string"
                 },
                 "updated_date": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -16889,6 +16889,12 @@
                 "id": {
                     "type": "string"
                 },
+                "reactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/thunderdome.RetroItemReaction"
+                    }
+                },
                 "type": {
                     "type": "string"
                 },
@@ -16910,6 +16916,29 @@
                     "type": "string"
                 },
                 "item_id": {
+                    "type": "string"
+                },
+                "updated_date": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "thunderdome.RetroItemReaction": {
+            "type": "object",
+            "properties": {
+                "created_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "item_id": {
+                    "type": "string"
+                },
+                "reaction": {
                     "type": "string"
                 },
                 "updated_date": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1429,6 +1429,10 @@ definitions:
         type: string
       id:
         type: string
+      reactions:
+        items:
+          $ref: '#/definitions/thunderdome.RetroItemReaction'
+        type: array
       type:
         type: string
       userId:
@@ -1443,6 +1447,21 @@ definitions:
       id:
         type: string
       item_id:
+        type: string
+      updated_date:
+        type: string
+      user_id:
+        type: string
+    type: object
+  thunderdome.RetroItemReaction:
+    properties:
+      created_date:
+        type: string
+      id:
+        type: string
+      item_id:
+        type: string
+      reaction:
         type: string
       updated_date:
         type: string

--- a/internal/db/migrations/20260416120000_add_retro_item_reaction.sql
+++ b/internal/db/migrations/20260416120000_add_retro_item_reaction.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS thunderdome.retro_item_reaction (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    item_id uuid REFERENCES thunderdome.retro_item(id) ON DELETE CASCADE,
+    user_id uuid REFERENCES thunderdome.users(id) ON DELETE CASCADE,
+    reaction text NOT NULL,
+    created_date timestamp with time zone DEFAULT now(),
+    updated_date timestamp with time zone DEFAULT now(),
+    UNIQUE (user_id, item_id, reaction)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS thunderdome.retro_item_reaction;
+-- +goose StatementEnd

--- a/internal/db/retro/item.go
+++ b/internal/db/retro/item.go
@@ -74,12 +74,23 @@ func (d *Service) GetRetroItems(retroID string) []*thunderdome.RetroItem {
 		`SELECT
 				ri.id, ri.user_id, ri.group_id, ri.content, ri.type,
 				COALESCE(
-					json_agg(rc ORDER BY rc.created_date) FILTER (WHERE rc.id IS NOT NULL), '[]'
-				) AS comments
+					(
+						SELECT json_agg(rc ORDER BY rc.created_date)
+						FROM thunderdome.retro_item_comment rc
+						WHERE rc.item_id = ri.id
+					),
+					'[]'
+				) AS comments,
+				COALESCE(
+					(
+						SELECT json_agg(rr ORDER BY rr.created_date)
+						FROM thunderdome.retro_item_reaction rr
+						WHERE rr.item_id = ri.id
+					),
+					'[]'
+				) AS reactions
 			FROM thunderdome.retro_item ri
-			LEFT JOIN thunderdome.retro_item_comment rc ON rc.item_id = ri.id
 			WHERE ri.retro_id = $1
-			GROUP BY ri.id, ri.created_date
 			ORDER BY ri.created_date ASC;`,
 		retroID,
 	)
@@ -87,15 +98,21 @@ func (d *Service) GetRetroItems(retroID string) []*thunderdome.RetroItem {
 		defer itemRows.Close()
 		for itemRows.Next() {
 			var comments string
+			var reactions string
 			var ri = &thunderdome.RetroItem{
-				Comments: make([]*thunderdome.RetroItemComment, 0),
+				Comments:  make([]*thunderdome.RetroItemComment, 0),
+				Reactions: make([]*thunderdome.RetroItemReaction, 0),
 			}
-			if err := itemRows.Scan(&ri.ID, &ri.UserID, &ri.GroupID, &ri.Content, &ri.Type, &comments); err != nil {
+			if err := itemRows.Scan(&ri.ID, &ri.UserID, &ri.GroupID, &ri.Content, &ri.Type, &comments, &reactions); err != nil {
 				d.Logger.Error("get retro items query scan error", zap.Error(err))
 			} else {
 				jsonErr := json.Unmarshal([]byte(comments), &ri.Comments)
 				if jsonErr != nil {
 					d.Logger.Error("retro item comments json error", zap.Error(jsonErr))
+				}
+				jsonErr = json.Unmarshal([]byte(reactions), &ri.Reactions)
+				if jsonErr != nil {
+					d.Logger.Error("retro item reactions json error", zap.Error(jsonErr))
 				}
 				items = append(items, ri)
 			}
@@ -189,6 +206,36 @@ func (d *Service) ItemCommentDelete(retroID string, commentID string) ([]*thunde
 		commentID,
 	); err != nil {
 		d.Logger.Error("ItemCommentDelete error", zap.Error(err))
+	}
+
+	items := d.GetRetroItems(retroID)
+
+	return items, nil
+}
+
+// ItemReactionAdd adds a reaction to a retro item
+func (d *Service) ItemReactionAdd(retroID string, itemID string, userID string, reaction string) ([]*thunderdome.RetroItem, error) {
+	if _, err := d.DB.Exec(
+		`INSERT INTO thunderdome.retro_item_reaction (item_id, user_id, reaction) VALUES ($1, $2, $3);`,
+		itemID,
+		userID,
+		reaction,
+	); err != nil {
+		d.Logger.Error("ItemReactionAdd error", zap.Error(err))
+	}
+
+	items := d.GetRetroItems(retroID)
+
+	return items, nil
+}
+
+// ItemReactionDelete deletes a retro item reaction
+func (d *Service) ItemReactionDelete(retroID string, reactionID string) ([]*thunderdome.RetroItem, error) {
+	if _, err := d.DB.Exec(
+		`DELETE FROM thunderdome.retro_item_reaction WHERE id = $1;`,
+		reactionID,
+	); err != nil {
+		d.Logger.Error("ItemReactionDelete error", zap.Error(err))
 	}
 
 	items := d.GetRetroItems(retroID)

--- a/internal/http/retro/events.go
+++ b/internal/http/retro/events.go
@@ -99,6 +99,49 @@ func (s *Service) ItemCommentDelete(ctx context.Context, RetroID string, UserID 
 	return nil, msg, nil, false
 }
 
+// ItemReactionAdd creates a retro item reaction
+func (s *Service) ItemReactionAdd(ctx context.Context, RetroID string, UserID string, EventValue string) (any, []byte, error, bool) {
+	var rs struct {
+		ItemID   string `json:"item_id"`
+		Reaction string `json:"reaction"`
+	}
+	err := json.Unmarshal([]byte(EventValue), &rs)
+	if err != nil {
+		return nil, nil, err, false
+	}
+
+	items, err := s.RetroService.ItemReactionAdd(RetroID, rs.ItemID, UserID, rs.Reaction)
+	if err != nil {
+		return nil, nil, err, false
+	}
+
+	updatedItems, _ := json.Marshal(items)
+	msg := wshub.CreateSocketEvent("items_updated", string(updatedItems), "")
+
+	return nil, msg, nil, false
+}
+
+// ItemReactionDelete deletes a retro item reaction
+func (s *Service) ItemReactionDelete(ctx context.Context, RetroID string, UserID string, EventValue string) (any, []byte, error, bool) {
+	var rs struct {
+		ReactionID string `json:"reaction_id"`
+	}
+	err := json.Unmarshal([]byte(EventValue), &rs)
+	if err != nil {
+		return nil, nil, err, false
+	}
+
+	items, err := s.RetroService.ItemReactionDelete(RetroID, rs.ReactionID)
+	if err != nil {
+		return nil, nil, err, false
+	}
+
+	updatedItems, _ := json.Marshal(items)
+	msg := wshub.CreateSocketEvent("items_updated", string(updatedItems), "")
+
+	return nil, msg, nil, false
+}
+
 // UserMarkReady marks a user as ready to advance to next phase
 func (s *Service) UserMarkReady(ctx context.Context, RetroID string, UserID string, EventValue string) (any, []byte, error, bool) {
 	readyUsers, err := s.RetroService.MarkUserReady(RetroID, UserID)

--- a/internal/http/retro/retro.go
+++ b/internal/http/retro/retro.go
@@ -66,6 +66,8 @@ type RetroDataSvc interface {
 	ItemCommentAdd(retroID string, itemID string, userID string, comment string) ([]*thunderdome.RetroItem, error)
 	ItemCommentEdit(retroID string, commentID string, comment string) ([]*thunderdome.RetroItem, error)
 	ItemCommentDelete(retroID string, commentID string) ([]*thunderdome.RetroItem, error)
+	ItemReactionAdd(retroID string, itemID string, userID string, reaction string) ([]*thunderdome.RetroItem, error)
+	ItemReactionDelete(retroID string, reactionID string) ([]*thunderdome.RetroItem, error)
 }
 
 type RetroTemplateDataSvc interface {
@@ -132,6 +134,8 @@ func New(
 		"item_comment_add":       s.ItemCommentAdd,
 		"item_comment_edit":      s.ItemCommentEdit,
 		"item_comment_delete":    s.ItemCommentDelete,
+		"item_reaction_add":      s.ItemReactionAdd,
+		"item_reaction_delete":   s.ItemReactionDelete,
 		"create_action":          s.CreateAction,
 		"update_action":          s.UpdateAction,
 		"delete_action":          s.DeleteAction,

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -505,6 +505,8 @@ type RetroDataSvc interface {
 	ItemCommentAdd(retroID string, itemID string, userID string, comment string) ([]*thunderdome.RetroItem, error)
 	ItemCommentEdit(retroID string, commentID string, comment string) ([]*thunderdome.RetroItem, error)
 	ItemCommentDelete(retroID string, commentID string) ([]*thunderdome.RetroItem, error)
+	ItemReactionAdd(retroID string, itemID string, userID string, reaction string) ([]*thunderdome.RetroItem, error)
+	ItemReactionDelete(retroID string, reactionID string) ([]*thunderdome.RetroItem, error)
 
 	GetSettingsByOrganization(ctx context.Context, orgID string) (*thunderdome.RetroSettings, error)
 	GetSettingsByDepartment(ctx context.Context, deptID string) (*thunderdome.RetroSettings, error)

--- a/thunderdome/retro.go
+++ b/thunderdome/retro.go
@@ -53,12 +53,13 @@ type Retro struct {
 
 // RetroItem can be a pro (went well/worked), con (needs improvement), or a question
 type RetroItem struct {
-	ID       string              `json:"id" db:"id"`
-	UserID   string              `json:"userId" db:"user_id"`
-	GroupID  string              `json:"groupId" db:"group_id"`
-	Content  string              `json:"content" db:"content"`
-	Type     string              `json:"type" db:"type"`
-	Comments []*RetroItemComment `json:"comments"`
+	ID        string               `json:"id" db:"id"`
+	UserID    string               `json:"userId" db:"user_id"`
+	GroupID   string               `json:"groupId" db:"group_id"`
+	Content   string               `json:"content" db:"content"`
+	Type      string               `json:"type" db:"type"`
+	Comments  []*RetroItemComment  `json:"comments"`
+	Reactions []*RetroItemReaction `json:"reactions"`
 }
 
 // RetroGroup is a grouping of retro items
@@ -93,6 +94,15 @@ type RetroItemComment struct {
 	ItemID      string `json:"item_id"`
 	UserID      string `json:"user_id"`
 	Comment     string `json:"comment"`
+	CreateDate  string `json:"created_date"`
+	UpdatedDate string `json:"updated_date"`
+}
+
+type RetroItemReaction struct {
+	ID          string `json:"id"`
+	ItemID      string `json:"item_id"`
+	UserID      string `json:"user_id"`
+	Reaction    string `json:"reaction"`
 	CreateDate  string `json:"created_date"`
 	UpdatedDate string `json:"updated_date"`
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4072,9 +4072,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/src/components/global/EmojiPicker.svelte
+++ b/ui/src/components/global/EmojiPicker.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import { Smile } from '@lucide/svelte';
+  import type { EmojiPickerItem } from './emoji-picker';
+
+  interface Props {
+    options?: EmojiPickerItem[];
+    disabled?: boolean;
+    onToggle?: (option: EmojiPickerItem) => void;
+    toggleAriaLabel?: string;
+    toggleTestId?: string;
+    popoverTestId?: string;
+  }
+
+  let {
+    options = [],
+    disabled = false,
+    onToggle = () => {},
+    toggleAriaLabel = 'Open emoji picker',
+    toggleTestId = 'emoji-picker-toggle',
+    popoverTestId = 'emoji-picker-popover',
+  }: Props = $props();
+
+  let showPicker = $state(false);
+
+  const activeOptions = $derived(options.filter(option => option.count > 0));
+  const pickerOptions = $derived(
+    options.map(option => ({
+      ...option,
+      pickerDisabled: disabled || option.pickerDisabled,
+    })),
+  );
+
+  function togglePicker() {
+    if (disabled) {
+      return;
+    }
+
+    showPicker = !showPicker;
+  }
+
+  function closePicker() {
+    showPicker = false;
+  }
+
+  function clickOutsidePicker(node: HTMLElement) {
+    function handleClick(event: MouseEvent) {
+      if (showPicker && !node.contains(event.target as Node)) {
+        closePicker();
+      }
+    }
+
+    document.addEventListener('click', handleClick, true);
+
+    return {
+      destroy() {
+        document.removeEventListener('click', handleClick, true);
+      },
+    };
+  }
+
+  const getReactionClasses = (selected: boolean) =>
+    selected
+      ? 'inline-flex items-center gap-1 rounded-full border border-blue-400 bg-blue-50 px-2.5 py-1 text-sm text-blue-700 transition-colors duration-200 dark:border-sky-500 dark:bg-sky-500/10 dark:text-sky-300'
+      : 'inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-sm text-gray-700 transition-colors duration-200 hover:border-blue-300 hover:text-blue-600 dark:border-gray-600 dark:bg-gray-800/60 dark:text-gray-200 dark:hover:border-sky-500 dark:hover:text-sky-300';
+
+  const getPickerButtonClasses = (optionDisabled: boolean) =>
+    optionDisabled
+      ? 'flex items-center justify-center rounded-lg px-2 py-2 text-xl opacity-40 cursor-not-allowed'
+      : 'flex items-center justify-center rounded-lg px-2 py-2 text-xl hover:bg-gray-100 dark:hover:bg-gray-700/70 transition-colors duration-150';
+
+  function handleToggle(option: EmojiPickerItem) {
+    if (disabled) {
+      return;
+    }
+
+    closePicker();
+    onToggle(option);
+  }
+</script>
+
+<div class="flex flex-wrap items-center gap-2" data-testid="emoji-picker">
+  {#each activeOptions as option}
+    <button
+      type="button"
+      class={getReactionClasses(Boolean(option.selected))}
+      class:cursor-not-allowed={disabled}
+      aria-label="{option.selected ? 'Remove' : 'Add'} {option.label} reaction"
+      data-testid="reaction-{option.key}"
+      onclick={() => handleToggle(option)}
+      {disabled}
+    >
+      <span aria-hidden="true">{option.value}</span>
+      <span class="font-medium">{option.count}</span>
+    </button>
+  {/each}
+
+  <div class="relative" use:clickOutsidePicker>
+    <button
+      type="button"
+      class="inline-flex items-center justify-center rounded-full border border-gray-200 bg-white p-2 text-gray-600 transition-colors duration-200 hover:border-blue-300 hover:text-blue-600 dark:border-gray-600 dark:bg-gray-800/60 dark:text-gray-200 dark:hover:border-sky-500 dark:hover:text-sky-300"
+      class:cursor-not-allowed={disabled}
+      aria-label={toggleAriaLabel}
+      aria-expanded={showPicker}
+      data-testid={toggleTestId}
+      onclick={togglePicker}
+      {disabled}
+    >
+      <Smile class="h-4 w-4" />
+    </button>
+
+    {#if showPicker}
+      <div
+        class="absolute left-0 top-full z-10 mt-2 flex gap-1 rounded-2xl border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+        data-testid={popoverTestId}
+      >
+        {#each pickerOptions as option}
+          <button
+            type="button"
+            class={getPickerButtonClasses(Boolean(option.pickerDisabled))}
+            aria-label="Add {option.label} reaction"
+            data-testid="reaction-picker-option-{option.key}"
+            onclick={() => handleToggle(option)}
+            disabled={option.pickerDisabled}
+          >
+            <span aria-hidden="true">{option.value}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/ui/src/components/global/emoji-picker.ts
+++ b/ui/src/components/global/emoji-picker.ts
@@ -13,6 +13,7 @@ export type EmojiPickerItem = EmojiPickerOption & {
 
 export const DEVELOPER_REACTION_OPTIONS: EmojiPickerOption[] = [
   { key: 'rocket', value: '🚀', label: 'rocket' },
+  { key: 'fire', value: '🔥', label: 'fire' },
   { key: 'thumbsdown', value: '👎', label: 'thumbs down' },
   { key: 'thumbsup', value: '👍', label: 'thumbs up' },
   { key: 'laugh', value: '😄', label: 'laugh' },

--- a/ui/src/components/global/emoji-picker.ts
+++ b/ui/src/components/global/emoji-picker.ts
@@ -1,0 +1,23 @@
+export type EmojiPickerOption = {
+  key: string;
+  value: string;
+  label: string;
+};
+
+export type EmojiPickerItem = EmojiPickerOption & {
+  count: number;
+  disabled?: boolean;
+  pickerDisabled?: boolean;
+  selected?: boolean;
+};
+
+export const DEVELOPER_REACTION_OPTIONS: EmojiPickerOption[] = [
+  { key: 'rocket', value: '🚀', label: 'rocket' },
+  { key: 'thumbsdown', value: '👎', label: 'thumbs down' },
+  { key: 'thumbsup', value: '👍', label: 'thumbs up' },
+  { key: 'laugh', value: '😄', label: 'laugh' },
+  { key: 'hooray', value: '🎉', label: 'hooray' },
+  { key: 'confused', value: '😕', label: 'confused' },
+  { key: 'heart', value: '❤️', label: 'heart' },
+  { key: 'eyes', value: '👀', label: 'eyes' },
+];

--- a/ui/src/components/retro/RetroFeedbackItem.svelte
+++ b/ui/src/components/retro/RetroFeedbackItem.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { MessageSquare, Trash2 } from '@lucide/svelte';
+  import EmojiPicker from '../global/EmojiPicker.svelte';
+  import { DEVELOPER_REACTION_OPTIONS, type EmojiPickerItem, type EmojiPickerOption } from '../global/emoji-picker';
   import ItemComments from './ItemComments.svelte';
   import { user } from '../../stores';
   import LL from '../../i18n/i18n-svelte';
-  import type { RetroItem } from '../../types/retro';
+  import type { RetroItem, RetroItemReaction } from '../../types/retro';
 
   interface Props {
     class?: string;
@@ -25,6 +27,7 @@
       type: '',
       content: '',
       comments: [],
+      reactions: [],
     },
     feedbackVisibility = 'visible',
     isFacilitator = false,
@@ -36,6 +39,23 @@
 
   let showComments = $state(false);
   let selectedItem = $state<RetroItem | null>(null);
+
+  const interactionsDisabled = $derived(phase === 'brainstorm' && feedbackVisibility === 'hidden');
+  const itemReactions = $derived((item.reactions ?? []) as RetroItemReaction[]);
+  const reactionSummary = $derived(
+    DEVELOPER_REACTION_OPTIONS.map((option: EmojiPickerOption) => {
+      const matchingReactions = itemReactions.filter(reaction => reaction.reaction === option.value);
+      const currentUserReaction = matchingReactions.find(reaction => reaction.user_id === $user.id);
+
+      return {
+        ...option,
+        count: matchingReactions.length,
+        currentUserReactionId: currentUserReaction?.id,
+        selected: currentUserReaction !== undefined,
+        pickerDisabled: interactionsDisabled || currentUserReaction !== undefined,
+      };
+    }),
+  );
 
   const toggleComments = (item: RetroItem | null) => () => {
     showComments = !showComments;
@@ -49,6 +69,27 @@
         id: item.id,
         type: item.type,
         phase,
+      }),
+    );
+  };
+
+  const handleReactionToggle = (reaction: EmojiPickerItem & { currentUserReactionId?: string }) => {
+    if (reaction.currentUserReactionId) {
+      sendSocketEvent(
+        'item_reaction_delete',
+        JSON.stringify({
+          reaction_id: reaction.currentUserReactionId,
+        }),
+      );
+
+      return;
+    }
+
+    sendSocketEvent(
+      'item_reaction_add',
+      JSON.stringify({
+        item_id: item.id,
+        reaction: reaction.value,
       }),
     );
   };
@@ -93,12 +134,12 @@
       {/if}
       <button
         class="inline-block leading-none text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-sky-400 transition-colors duration-200"
-        class:cursor-not-allowed={phase === 'brainstorm' && feedbackVisibility === 'hidden'}
+        class:cursor-not-allowed={interactionsDisabled}
         onclick={toggleComments(item)}
-        disabled={phase === 'brainstorm' && feedbackVisibility === 'hidden'}
+        disabled={interactionsDisabled}
       >
         <MessageSquare class="inline w-4 h-4" />
-        <span data-testid="retro-feedback-item-comments">{item.comments.length}</span>
+        <span data-testid="retro-feedback-item-comments">{item.comments?.length ?? 0}</span>
       </button>
     </div>
     {#if phase === 'brainstorm' && item.userId === $user.id}
@@ -122,6 +163,16 @@
       {item.content}
     {/if}
   </p>
+  <div class="mt-3 flex flex-wrap items-center gap-2" data-testid="retro-feedback-item-reactions">
+    <EmojiPicker
+      options={reactionSummary}
+      disabled={interactionsDisabled}
+      onToggle={handleReactionToggle}
+      toggleAriaLabel="Open reaction picker"
+      toggleTestId="reaction-picker-toggle"
+      popoverTestId="reaction-picker-popover"
+    />
+  </div>
   {@render children?.()}
 
   {#if showComments}

--- a/ui/src/components/retro/RetroFeedbackItem.test.ts
+++ b/ui/src/components/retro/RetroFeedbackItem.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+
+import { user } from '../../stores';
+import RetroFeedbackItem from './RetroFeedbackItem.svelte';
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Alex Doe',
+  createdDate: '2024-01-01T00:00:00.000Z',
+  updatedDate: '2024-01-01T00:00:00.000Z',
+  lastActive: '2024-01-01T00:00:00.000Z',
+  locale: 'en',
+  rank: 'warrior',
+  subscribed: true,
+};
+
+const baseItem = {
+  id: 'item-1',
+  type: 'worked_well',
+  content: 'Ship it',
+  userId: 'user-1',
+  groupId: 'group-1',
+  comments: [],
+  reactions: [
+    {
+      id: 'reaction-1',
+      item_id: 'item-1',
+      user_id: 'user-2',
+      reaction: '🚀',
+      created_date: '2024-01-01T00:00:00.000Z',
+      updated_date: '2024-01-01T00:00:00.000Z',
+    },
+  ],
+};
+
+const setup = (overrides?: {
+  item?: typeof baseItem;
+  phase?: string;
+  feedbackVisibility?: string;
+  sendSocketEvent?: (event: string, value: any) => void;
+}) => {
+  const {
+    item = baseItem,
+    phase = 'group',
+    feedbackVisibility = 'visible',
+    sendSocketEvent = vi.fn(),
+  } = overrides || {};
+
+  user.create({
+    ...baseUser,
+    id: baseUser.id,
+  });
+
+  return {
+    sendSocketEvent,
+    ...render(RetroFeedbackItem, {
+      item,
+      phase,
+      feedbackVisibility,
+      sendSocketEvent,
+      users: [],
+      columnColors: {},
+    }),
+  };
+};
+
+describe('RetroFeedbackItem component reactions', () => {
+  it('renders only active reaction counts by default', () => {
+    setup();
+
+    const rocketReaction = page.getByTestId('reaction-rocket');
+    expect(rocketReaction).toHaveTextContent('🚀 1');
+    expect(page.getByTestId('reaction-picker-toggle')).toBeTruthy();
+  });
+
+  it('opens the picker and sends add reaction socket event for a new reaction', async () => {
+    const sendSocketEvent = vi.fn();
+    setup({ sendSocketEvent });
+
+    const reactionPickerToggle = page.getByTestId('reaction-picker-toggle');
+    await userEvent.click(reactionPickerToggle);
+
+    const reactionPopover = page.getByTestId('reaction-picker-popover');
+    expect(reactionPopover).toBeTruthy();
+
+    const thumbsDownReaction = page.getByTestId('reaction-picker-option-thumbsdown');
+    await userEvent.click(thumbsDownReaction);
+
+    expect(sendSocketEvent).toHaveBeenCalledWith(
+      'item_reaction_add',
+      JSON.stringify({
+        item_id: 'item-1',
+        reaction: '👎',
+      }),
+    );
+  });
+
+  it('sends delete reaction socket event when toggling an existing user reaction', async () => {
+    const sendSocketEvent = vi.fn();
+    setup({
+      sendSocketEvent,
+      item: {
+        ...baseItem,
+        reactions: [
+          ...baseItem.reactions,
+          {
+            id: 'reaction-2',
+            item_id: 'item-1',
+            user_id: 'user-1',
+            reaction: '🚀',
+            created_date: '2024-01-01T00:00:00.000Z',
+            updated_date: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    const rocketReaction = page.getByTestId('reaction-rocket');
+    await userEvent.click(rocketReaction);
+
+    expect(sendSocketEvent).toHaveBeenCalledWith(
+      'item_reaction_delete',
+      JSON.stringify({
+        reaction_id: 'reaction-2',
+      }),
+    );
+  });
+
+  it('disables picker options for reactions already used by the current user', async () => {
+    setup({
+      item: {
+        ...baseItem,
+        reactions: [
+          {
+            id: 'reaction-2',
+            item_id: 'item-1',
+            user_id: 'user-1',
+            reaction: '👎',
+            created_date: '2024-01-01T00:00:00.000Z',
+            updated_date: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    await userEvent.click(page.getByTestId('reaction-picker-toggle'));
+
+    const thumbsDownReaction = page.getByTestId('reaction-picker-option-thumbsdown');
+    expect(thumbsDownReaction).toBeDisabled();
+  });
+});

--- a/ui/src/types/retro.ts
+++ b/ui/src/types/retro.ts
@@ -36,6 +36,24 @@ export type RetroActionComment = {
   user_id: string;
 };
 
+export type RetroItemComment = {
+  comment: string;
+  created_date: string;
+  id: string;
+  item_id: string;
+  updated_date: string;
+  user_id: string;
+};
+
+export type RetroItemReaction = {
+  created_date: string;
+  id: string;
+  item_id: string;
+  reaction: string;
+  updated_date: string;
+  user_id: string;
+};
+
 export type RetroGroup = {
   id: string;
   name: string;
@@ -44,9 +62,11 @@ export type RetroGroup = {
 };
 
 export type RetroItem = {
+  comments?: Array<RetroItemComment>;
   content: string;
   groupId: string;
   id: string;
+  reactions?: Array<RetroItemReaction>;
   type: string;
   userId: string;
 };


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CONTRIBUTING.md.
  - 📖 Read the Code of Conduct: https://github.com/stevenweathers/thunderdome-planning-poker/blob/main/docs/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide or update applicable tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

Adds Retro Item Emoji Reactions, with a default set of reactions common to retros.  Additional reactions could be added in the future.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

This resolves #588 by adding Retro Item Reactions, not going to add Stickers.

## Screenshots/Recordings

<img width="707" height="352" alt="image" src="https://github.com/user-attachments/assets/e5f88f54-c027-4fed-9289-a24e969f57e4" />

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->