### PR TITLE
Add request body size limit

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -618,6 +618,7 @@ func New(apiService Service, FSS fs.FS, HFS http.FileSystem) *Service {
 	}))
 
 	var handler http.Handler = router
+	handler = a.requestBodyLimit(handler, prefix)
 	handler = a.panicRecovery(handler)
 	handler = otelhttp.NewHandler(handler, "thunderdome")
 	handler = cspMiddleware(handler, secureMiddleware, prefix, a.Config.ExternalAPIEnabled)

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,8 +1,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -10,6 +13,8 @@ import (
 
 	"github.com/StevenWeathers/thunderdome-planning-poker/thunderdome"
 )
+
+const maxJSONRequestBodyBytes = int64(65536)
 
 func (s *Service) panicRecovery(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -22,6 +27,45 @@ func (s *Service) panicRecovery(h http.Handler) http.Handler {
 
 		h.ServeHTTP(w, r)
 	})
+}
+
+func (s *Service) requestBodyLimit(h http.Handler, prefix string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !shouldLimitJSONRequestBody(r, prefix) {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		limitedBody := http.MaxBytesReader(w, r.Body, maxJSONRequestBodyBytes)
+		defer limitedBody.Close()
+
+		body, err := io.ReadAll(limitedBody)
+		if err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				s.Failure(w, r, http.StatusRequestEntityTooLarge, Errorf(EINVALID, "REQUEST_TOO_LARGE"))
+				return
+			}
+
+			s.Failure(w, r, http.StatusBadRequest, Errorf(EINVALID, err.Error()))
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		h.ServeHTTP(w, r)
+	})
+}
+
+func shouldLimitJSONRequestBody(r *http.Request, prefix string) bool {
+	if r.Body == nil || r.Body == http.NoBody {
+		return false
+	}
+
+	if r.Method != http.MethodPost && r.Method != http.MethodPut && r.Method != http.MethodPatch {
+		return false
+	}
+
+	return strings.HasPrefix(r.URL.Path, prefix+"/api/")
 }
 
 // userOnly validates that the request was made by a valid user

--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -1,14 +1,18 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest/observer"
 
@@ -334,6 +338,67 @@ func TestTeamUserOnly(t *testing.T) {
 			mockLogger.AssertExpectations(t)
 		})
 	}
+}
+
+func TestRequestBodyLimitRejectsOversizedJSONRequests(t *testing.T) {
+	service := &Service{}
+	nextCalled := false
+	handler := service.requestBodyLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}), "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth", bytes.NewReader(bytes.Repeat([]byte("a"), int(maxJSONRequestBodyBytes)+1)))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.False(t, nextCalled)
+	require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+
+	var response standardJsonResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+	require.False(t, response.Success)
+	require.Equal(t, "REQUEST_TOO_LARGE", response.Error)
+}
+
+func TestRequestBodyLimitPreservesNormalSizedJSONRequests(t *testing.T) {
+	service := &Service{}
+	expectedBody := `{"email":"user@example.com","password":"secret123"}`
+	var actualBody string
+
+	handler := service.requestBodyLimit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		actualBody = string(body)
+		w.WriteHeader(http.StatusNoContent)
+	}), "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth", strings.NewReader(expectedBody))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	require.Equal(t, expectedBody, actualBody)
+}
+
+func TestRequestBodyLimitAllowsMalformedJSONResponsesToStayBadRequest(t *testing.T) {
+	validate = validator.New()
+	service := &Service{}
+	handler := service.requestBodyLimit(service.handleLogin(), "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth", strings.NewReader("{"))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var response standardJsonResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+	require.False(t, response.Success)
+	require.Contains(t, response.Error, "unexpected end of JSON input")
 }
 
 func TestTeamAdminOnly(t *testing.T) {


### PR DESCRIPTION
## Description

Add request body size limit to safeguard APIs added a request body size limit

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->