### PR TITLE
Add storyboard goal and column default story color settings

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -15893,7 +15893,13 @@ const docTemplate = `{
                 "goalId"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "goalId": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }
@@ -15904,6 +15910,9 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 }
@@ -15938,6 +15947,9 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string",
                     "minLength": 1
@@ -15950,6 +15962,9 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string",
                     "minLength": 1
@@ -15963,6 +15978,9 @@ const docTemplate = `{
                 "goalId"
             ],
             "properties": {
+                "color": {
+                    "type": "string"
+                },
                 "columnId": {
                     "type": "string"
                 },
@@ -17485,6 +17503,9 @@ const docTemplate = `{
         "thunderdome.StoryboardColumn": {
             "type": "object",
             "properties": {
+                "default_story_color": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -17516,6 +17537,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/thunderdome.StoryboardColumn"
                     }
+                },
+                "default_story_color": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "string"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -15885,7 +15885,13 @@
                 "goalId"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "goalId": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }
@@ -15896,6 +15902,9 @@
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 }
@@ -15930,6 +15939,9 @@
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string",
                     "minLength": 1
@@ -15942,6 +15954,9 @@
                 "name"
             ],
             "properties": {
+                "defaultStoryColor": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string",
                     "minLength": 1
@@ -15955,6 +15970,9 @@
                 "goalId"
             ],
             "properties": {
+                "color": {
+                    "type": "string"
+                },
                 "columnId": {
                     "type": "string"
                 },
@@ -17477,6 +17495,9 @@
         "thunderdome.StoryboardColumn": {
             "type": "object",
             "properties": {
+                "default_story_color": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -17508,6 +17529,9 @@
                     "items": {
                         "$ref": "#/definitions/thunderdome.StoryboardColumn"
                     }
+                },
+                "default_story_color": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "string"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -634,13 +634,19 @@ definitions:
     type: object
   http.storyboardColumnAddRequestBody:
     properties:
+      defaultStoryColor:
+        type: string
       goalId:
+        type: string
+      name:
         type: string
     required:
     - goalId
     type: object
   http.storyboardColumnUpdateRequestBody:
     properties:
+      defaultStoryColor:
+        type: string
       name:
         type: string
     required:
@@ -663,6 +669,8 @@ definitions:
     type: object
   http.storyboardGoalAddRequestBody:
     properties:
+      defaultStoryColor:
+        type: string
       name:
         minLength: 1
         type: string
@@ -671,6 +679,8 @@ definitions:
     type: object
   http.storyboardGoalUpdateRequestBody:
     properties:
+      defaultStoryColor:
+        type: string
       name:
         minLength: 1
         type: string
@@ -679,6 +689,8 @@ definitions:
     type: object
   http.storyboardStoryAddRequestBody:
     properties:
+      color:
+        type: string
       columnId:
         type: string
       goalId:
@@ -1692,6 +1704,8 @@ definitions:
     type: object
   thunderdome.StoryboardColumn:
     properties:
+      default_story_color:
+        type: string
       id:
         type: string
       name:
@@ -1713,6 +1727,8 @@ definitions:
         items:
           $ref: '#/definitions/thunderdome.StoryboardColumn'
         type: array
+      default_story_color:
+        type: string
       id:
         type: string
       name:

--- a/internal/db/migrations/20260509130000_add_storyboard_default_story_colors.sql
+++ b/internal/db/migrations/20260509130000_add_storyboard_default_story_colors.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE thunderdome.storyboard_goal ADD COLUMN IF NOT EXISTS default_story_color character varying(32);
+ALTER TABLE thunderdome.storyboard_column ADD COLUMN IF NOT EXISTS default_story_color character varying(32);
+
+-- +goose Down
+ALTER TABLE thunderdome.storyboard_column DROP COLUMN IF EXISTS default_story_color;
+ALTER TABLE thunderdome.storyboard_goal DROP COLUMN IF EXISTS default_story_color;

--- a/internal/db/storyboard/column.go
+++ b/internal/db/storyboard/column.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CreateStoryboardColumn adds a new column to a Storyboard
-func (d *Service) CreateStoryboardColumn(storyboardID string, goalID string, userID string) (*thunderdome.StoryboardColumn, error) {
+func (d *Service) CreateStoryboardColumn(storyboardID string, goalID string, userID string, columnName string, defaultStoryColor *string) (*thunderdome.StoryboardColumn, error) {
 	var betweenAkey *string
 	var logger = d.Logger.With(
 		zap.String("user_id", userID),
@@ -60,15 +60,17 @@ func (d *Service) CreateStoryboardColumn(storyboardID string, goalID string, use
 	}
 
 	column := thunderdome.StoryboardColumn{
-		Personas:  make([]*thunderdome.StoryboardPersona, 0),
-		Stories:   make([]*thunderdome.StoryboardStory, 0),
-		SortOrder: *displayOrder,
+		Name:              columnName,
+		DefaultStoryColor: defaultStoryColor,
+		Personas:          make([]*thunderdome.StoryboardPersona, 0),
+		Stories:           make([]*thunderdome.StoryboardStory, 0),
+		SortOrder:         *displayOrder,
 	}
 
 	if err := tx.QueryRow(
-		`INSERT INTO thunderdome.storyboard_column (storyboard_id, goal_id, display_order)
-		VALUES ($1, $2, $3) RETURNING id;`,
-		storyboardID, goalID, displayOrder,
+		`INSERT INTO thunderdome.storyboard_column (storyboard_id, goal_id, name, display_order, default_story_color)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id;`,
+		storyboardID, goalID, columnName, displayOrder, defaultStoryColor,
 	).Scan(&column.ID); err != nil {
 		logger.Error("CreateStoryboardColumn error",
 			zap.Error(err),
@@ -86,11 +88,16 @@ func (d *Service) CreateStoryboardColumn(storyboardID string, goalID string, use
 }
 
 // ReviseStoryboardColumn revises a storyboard column
-func (d *Service) ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string) ([]*thunderdome.StoryboardGoal, error) {
+func (d *Service) ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error) {
 	if _, err := d.DB.Exec(
-		`UPDATE thunderdome.storyboard_column SET name = $2, updated_date = NOW() WHERE id = $1;`,
+		`UPDATE thunderdome.storyboard_column
+		SET name = $2,
+			default_story_color = $3,
+			updated_date = NOW()
+		WHERE id = $1;`,
 		columnID,
 		columnName,
+		defaultStoryColor,
 	); err != nil {
 		d.Logger.Error("revise storyboard column error", zap.Error(err))
 	}

--- a/internal/db/storyboard/goal.go
+++ b/internal/db/storyboard/goal.go
@@ -2,6 +2,7 @@ package storyboard
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,8 +14,18 @@ import (
 	"go.uber.org/zap"
 )
 
+func nullableStringPointer(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+
+	stringValue := value.String
+
+	return &stringValue
+}
+
 // CreateStoryboardGoal adds a new goal to a Storyboard
-func (d *Service) CreateStoryboardGoal(storyboardID string, userID string, goalName string) (*thunderdome.StoryboardGoal, error) {
+func (d *Service) CreateStoryboardGoal(storyboardID string, userID string, goalName string, defaultStoryColor *string) (*thunderdome.StoryboardGoal, error) {
 	var betweenAkey *string
 	var logger = d.Logger.With(
 		zap.String("user_id", userID),
@@ -63,18 +74,19 @@ func (d *Service) CreateStoryboardGoal(storyboardID string, userID string, goalN
 	}
 
 	goal := thunderdome.StoryboardGoal{
-		Name:      goalName,
-		Personas:  make([]*thunderdome.StoryboardPersona, 0),
-		Columns:   make([]*thunderdome.StoryboardColumn, 0),
-		SortOrder: *displayOrder,
+		Name:              goalName,
+		DefaultStoryColor: defaultStoryColor,
+		Personas:          make([]*thunderdome.StoryboardPersona, 0),
+		Columns:           make([]*thunderdome.StoryboardColumn, 0),
+		SortOrder:         *displayOrder,
 	}
 
 	if err := tx.QueryRow(
 		`INSERT INTO
         thunderdome.storyboard_goal
-        (storyboard_id, name, display_order)
-        VALUES ($1, $2, $3) RETURNING id;`,
-		storyboardID, goalName, displayOrder,
+		(storyboard_id, name, display_order, default_story_color)
+		VALUES ($1, $2, $3, $4) RETURNING id;`,
+		storyboardID, goalName, displayOrder, defaultStoryColor,
 	).Scan(&goal.ID); err != nil {
 		logger.Error("create storyboard goal error",
 			zap.Error(err),
@@ -92,11 +104,16 @@ func (d *Service) CreateStoryboardGoal(storyboardID string, userID string, goalN
 }
 
 // ReviseGoalName updates the plan name by ID
-func (d *Service) ReviseGoalName(storyboardID string, userID string, goalID string, goalName string) ([]*thunderdome.StoryboardGoal, error) {
+func (d *Service) ReviseGoalName(storyboardID string, userID string, goalID string, goalName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error) {
 	if _, err := d.DB.Exec(
-		`UPDATE thunderdome.storyboard_goal SET name = $2, updated_date = NOW() WHERE id = $1;`,
+		`UPDATE thunderdome.storyboard_goal
+		SET name = $2,
+			default_story_color = $3,
+			updated_date = NOW()
+		WHERE id = $1;`,
 		goalID,
 		goalName,
+		defaultStoryColor,
 	); err != nil {
 		d.Logger.Error("update storyboard goal error", zap.Error(err))
 	}
@@ -127,6 +144,7 @@ func (d *Service) GetStoryboardGoals(storyboardID string) []*thunderdome.Storybo
             sg.id,
             sg.display_order,
             sg.name,
+			sg.default_story_color,
             COALESCE(json_agg(to_jsonb(t) - 'goal_id' ORDER BY t.display_order) FILTER (WHERE t.id IS NOT NULL), '[]') AS columns,
             (SELECT COALESCE(json_agg(to_jsonb(sp)) FILTER (WHERE gp.goal_id IS NOT NULL), '[]') AS personas
             FROM thunderdome.storyboard_goal_persona gp
@@ -167,15 +185,18 @@ func (d *Service) GetStoryboardGoals(storyboardID string) []*thunderdome.Storybo
 		for goalRows.Next() {
 			var columns string
 			var personas string
+			var defaultStoryColor sql.NullString
 			var sg = &thunderdome.StoryboardGoal{
-				ID:        "",
-				Name:      "",
-				SortOrder: "",
-				Columns:   make([]*thunderdome.StoryboardColumn, 0),
+				ID:                "",
+				Name:              "",
+				DefaultStoryColor: nil,
+				SortOrder:         "",
+				Columns:           make([]*thunderdome.StoryboardColumn, 0),
 			}
-			if err := goalRows.Scan(&sg.ID, &sg.SortOrder, &sg.Name, &columns, &personas); err != nil {
+			if err := goalRows.Scan(&sg.ID, &sg.SortOrder, &sg.Name, &defaultStoryColor, &columns, &personas); err != nil {
 				d.Logger.Error("get_storyboard_goals query scan error", zap.Error(err))
 			} else {
+				sg.DefaultStoryColor = nullableStringPointer(defaultStoryColor)
 				goalColumns := make([]*thunderdome.StoryboardColumn, 0)
 				jsonErr := json.Unmarshal([]byte(columns), &goalColumns)
 				if jsonErr != nil {
@@ -199,20 +220,23 @@ func (d *Service) GetStoryboardGoals(storyboardID string) []*thunderdome.Storybo
 // GetStoryboardGoal retrieves a specific goal by ID
 func (d *Service) GetStoryboardGoal(storyboardID string, goalID string) (*thunderdome.StoryboardGoal, error) {
 	var sg = &thunderdome.StoryboardGoal{
-		ID:        "",
-		Name:      "",
-		SortOrder: "",
-		Columns:   make([]*thunderdome.StoryboardColumn, 0),
-		Personas:  make([]*thunderdome.StoryboardPersona, 0),
+		ID:                "",
+		Name:              "",
+		DefaultStoryColor: nil,
+		SortOrder:         "",
+		Columns:           make([]*thunderdome.StoryboardColumn, 0),
+		Personas:          make([]*thunderdome.StoryboardPersona, 0),
 	}
 	var columns string
 	var personas string
+	var defaultStoryColor sql.NullString
 
 	goalErr := d.DB.QueryRow(
 		`SELECT
             sg.id,
             sg.display_order,
             sg.name,
+			sg.default_story_color,
             COALESCE(json_agg(to_jsonb(t) - 'goal_id' ORDER BY t.display_order) FILTER (WHERE t.id IS NOT NULL), '[]') AS columns,
             (SELECT COALESCE(json_agg(to_jsonb(sp)) FILTER (WHERE gp.goal_id IS NOT NULL), '[]') AS personas
             FROM thunderdome.storyboard_goal_persona gp
@@ -247,11 +271,12 @@ func (d *Service) GetStoryboardGoal(storyboardID string, goalID string) (*thunde
         GROUP BY sg.id, sg.display_order
         ORDER BY sg.display_order;`,
 		storyboardID, goalID,
-	).Scan(&sg.ID, &sg.SortOrder, &sg.Name, &columns, &personas)
+	).Scan(&sg.ID, &sg.SortOrder, &sg.Name, &defaultStoryColor, &columns, &personas)
 	if goalErr != nil {
 		d.Logger.Error("get_storyboard_goal query scan error", zap.Error(goalErr))
 		return sg, goalErr
 	}
+	sg.DefaultStoryColor = nullableStringPointer(defaultStoryColor)
 
 	goalColumns := make([]*thunderdome.StoryboardColumn, 0)
 	jsonErr := json.Unmarshal([]byte(columns), &goalColumns)

--- a/internal/db/storyboard/story.go
+++ b/internal/db/storyboard/story.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreateStoryboardStory adds a new story to a Storyboard
-func (d *Service) CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string) (*thunderdome.StoryboardStory, error) {
+func (d *Service) CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string, storyColor *string) (*thunderdome.StoryboardStory, error) {
 	var betweenAkey *string
 	var logger = d.Logger.With(
 		zap.String("user_id", userID),
@@ -67,11 +67,22 @@ func (d *Service) CreateStoryboardStory(storyboardID string, goalID string, colu
 		SortOrder:   *displayOrder,
 	}
 
-	if err := d.DB.QueryRow(
-		`INSERT INTO thunderdome.storyboard_story (storyboard_id, goal_id, column_id, display_order)
-		VALUES ($1, $2, $3, $4) RETURNING id;`,
-		storyboardID, goalID, columnID, displayOrder,
-	).Scan(&story.ID); err != nil {
+	if err := tx.QueryRow(
+		`INSERT INTO thunderdome.storyboard_story (storyboard_id, goal_id, column_id, display_order, color)
+		VALUES (
+			$1,
+			$2,
+			$3,
+			$4,
+			COALESCE(
+				$5,
+				(SELECT default_story_color FROM thunderdome.storyboard_column WHERE id = $3),
+				(SELECT default_story_color FROM thunderdome.storyboard_goal WHERE id = $2),
+				'gray'
+			)
+		) RETURNING id, color;`,
+		storyboardID, goalID, columnID, displayOrder, storyColor,
+	).Scan(&story.ID, &story.Color); err != nil {
 		logger.Error(
 			"create story error",
 			zap.Error(err),

--- a/internal/http/storyboard/events.go
+++ b/internal/http/storyboard/events.go
@@ -10,7 +10,16 @@ import (
 
 // AddGoal handles adding a goal to storyboard
 func (s *Service) AddGoal(ctx context.Context, storyboardID string, userID string, eventValue string) (any, []byte, error, bool) {
-	goal, err := s.StoryboardService.CreateStoryboardGoal(storyboardID, userID, eventValue)
+	var goalInput struct {
+		Name              string  `json:"name"`
+		DefaultStoryColor *string `json:"defaultStoryColor"`
+	}
+	err := json.Unmarshal([]byte(eventValue), &goalInput)
+	if err != nil {
+		return nil, nil, err, false
+	}
+
+	goal, err := s.StoryboardService.CreateStoryboardGoal(storyboardID, userID, goalInput.Name, goalInput.DefaultStoryColor)
 	if err != nil {
 		return nil, nil, err, false
 	}
@@ -23,15 +32,17 @@ func (s *Service) AddGoal(ctx context.Context, storyboardID string, userID strin
 
 // ReviseGoal handles revising a storyboard goal
 func (s *Service) ReviseGoal(ctx context.Context, storyboardID string, userID string, eventValue string) (any, []byte, error, bool) {
-	goalObj := make(map[string]string)
+	var goalObj struct {
+		GoalID            string  `json:"goalId"`
+		Name              string  `json:"name"`
+		DefaultStoryColor *string `json:"defaultStoryColor"`
+	}
 	err := json.Unmarshal([]byte(eventValue), &goalObj)
 	if err != nil {
 		return nil, nil, err, false
 	}
-	goalID := goalObj["goalId"]
-	goalName := goalObj["name"]
 
-	goals, err := s.StoryboardService.ReviseGoalName(storyboardID, userID, goalID, goalName)
+	goals, err := s.StoryboardService.ReviseGoalName(storyboardID, userID, goalObj.GoalID, goalObj.Name, goalObj.DefaultStoryColor)
 	if err != nil {
 		return nil, nil, err, false
 	}
@@ -55,14 +66,17 @@ func (s *Service) DeleteGoal(ctx context.Context, storyboardID string, userID st
 
 // AddColumn handles adding a column to storyboard goal
 func (s *Service) AddColumn(ctx context.Context, storyboardID string, userID string, eventValue string) (any, []byte, error, bool) {
-	goalObj := make(map[string]string)
-	err := json.Unmarshal([]byte(eventValue), &goalObj)
+	var columnInput struct {
+		GoalID            string  `json:"goalId"`
+		Name              string  `json:"name"`
+		DefaultStoryColor *string `json:"defaultStoryColor"`
+	}
+	err := json.Unmarshal([]byte(eventValue), &columnInput)
 	if err != nil {
 		return nil, nil, err, false
 	}
-	goalID := goalObj["goalId"]
 
-	column, err := s.StoryboardService.CreateStoryboardColumn(storyboardID, goalID, userID)
+	column, err := s.StoryboardService.CreateStoryboardColumn(storyboardID, columnInput.GoalID, userID, columnInput.Name, columnInput.DefaultStoryColor)
 	if err != nil {
 		return nil, nil, err, false
 	}
@@ -75,16 +89,17 @@ func (s *Service) AddColumn(ctx context.Context, storyboardID string, userID str
 
 // ReviseColumn handles revising a storyboard goal column
 func (s *Service) ReviseColumn(ctx context.Context, storyboardID string, userID string, eventValue string) (any, []byte, error, bool) {
-	var rs struct {
-		ColumnID string `json:"id"`
-		Name     string `json:"name"`
+	var columnObj struct {
+		ColumnID          string  `json:"id"`
+		Name              string  `json:"name"`
+		DefaultStoryColor *string `json:"defaultStoryColor"`
 	}
-	err := json.Unmarshal([]byte(eventValue), &rs)
+	err := json.Unmarshal([]byte(eventValue), &columnObj)
 	if err != nil {
 		return nil, nil, err, false
 	}
 
-	goals, err := s.StoryboardService.ReviseStoryboardColumn(storyboardID, userID, rs.ColumnID, rs.Name)
+	goals, err := s.StoryboardService.ReviseStoryboardColumn(storyboardID, userID, columnObj.ColumnID, columnObj.Name, columnObj.DefaultStoryColor)
 	if err != nil {
 		return nil, nil, err, false
 	}
@@ -179,15 +194,16 @@ func (s *Service) ColumnPersonaRemove(ctx context.Context, storyboardID string, 
 // AddStory handles adding a story to storyboard
 func (s *Service) AddStory(ctx context.Context, storyboardID string, userID string, eventValue string) (any, []byte, error, bool) {
 	var ns struct {
-		GoalID   string `json:"goalId"`
-		ColumnID string `json:"columnId"`
+		GoalID   string  `json:"goalId"`
+		ColumnID string  `json:"columnId"`
+		Color    *string `json:"color"`
 	}
 	err := json.Unmarshal([]byte(eventValue), &ns)
 	if err != nil {
 		return nil, nil, err, false
 	}
 
-	story, err := s.StoryboardService.CreateStoryboardStory(storyboardID, ns.GoalID, ns.ColumnID, userID)
+	story, err := s.StoryboardService.CreateStoryboardStory(storyboardID, ns.GoalID, ns.ColumnID, userID, ns.Color)
 	if err != nil {
 		return nil, nil, err, false
 	}

--- a/internal/http/storyboard/storyboard.go
+++ b/internal/http/storyboard/storyboard.go
@@ -53,20 +53,20 @@ type StoryboardDataSvc interface {
 	UpdateStoryboardPersona(storyboardID string, userID string, personaID string, name string, role string, description string) ([]*thunderdome.StoryboardPersona, error)
 	DeleteStoryboardPersona(storyboardID string, userID string, personaID string) ([]*thunderdome.StoryboardPersona, error)
 
-	CreateStoryboardGoal(storyboardID string, userID string, goalName string) (*thunderdome.StoryboardGoal, error)
-	ReviseGoalName(storyboardID string, userID string, goalID string, goalName string) ([]*thunderdome.StoryboardGoal, error)
+	CreateStoryboardGoal(storyboardID string, userID string, goalName string, defaultStoryColor *string) (*thunderdome.StoryboardGoal, error)
+	ReviseGoalName(storyboardID string, userID string, goalID string, goalName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error)
 	DeleteStoryboardGoal(storyboardID string, userID string, goalID string) ([]*thunderdome.StoryboardGoal, error)
 	GetStoryboardGoals(storyboardID string) []*thunderdome.StoryboardGoal
 	GetStoryboardGoal(storyboardID string, goalID string) (*thunderdome.StoryboardGoal, error)
 
-	CreateStoryboardColumn(storyboardID string, goalID string, userID string) (*thunderdome.StoryboardColumn, error)
-	ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string) ([]*thunderdome.StoryboardGoal, error)
+	CreateStoryboardColumn(storyboardID string, goalID string, userID string, columnName string, defaultStoryColor *string) (*thunderdome.StoryboardColumn, error)
+	ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error)
 	DeleteStoryboardColumn(storyboardID string, userID string, columnID string) ([]*thunderdome.StoryboardGoal, error)
 	ColumnPersonaAdd(storyboardID string, columnID string, personaID string) ([]*thunderdome.StoryboardGoal, error)
 	ColumnPersonaRemove(storyboardID string, columnID string, personaID string) ([]*thunderdome.StoryboardGoal, error)
 	MoveStoryboardColumn(storyboardID string, userID string, columnID string, goalID string, placeBeforeID string) error
 
-	CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string) (*thunderdome.StoryboardStory, error)
+	CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string, storyColor *string) (*thunderdome.StoryboardStory, error)
 	ReviseStoryName(storyboardID string, userID string, storyID string, storyName string) ([]*thunderdome.StoryboardGoal, error)
 	ReviseStoryContent(storyboardID string, userID string, storyID string, storyContent string) ([]*thunderdome.StoryboardGoal, error)
 	ReviseStoryColor(storyboardID string, userID string, storyID string, storyColor string) ([]*thunderdome.StoryboardGoal, error)

--- a/internal/http/storyboard_column.go
+++ b/internal/http/storyboard_column.go
@@ -11,7 +11,9 @@ import (
 )
 
 type storyboardColumnAddRequestBody struct {
-	GoalID string `json:"goalId" validate:"required,uuid"`
+	GoalID            string  `json:"goalId" validate:"required,uuid"`
+	Name              string  `json:"name"`
+	DefaultStoryColor *string `json:"defaultStoryColor"`
 }
 
 // handleStoryboardColumnAdd handles adding a column to a storyboard goal
@@ -79,7 +81,8 @@ func (s *Service) handleStoryboardColumnAdd(sb *storyboard.Service) http.Handler
 }
 
 type storyboardColumnUpdateRequestBody struct {
-	Name string `json:"name" validate:"required"`
+	Name              string  `json:"name" validate:"required"`
+	DefaultStoryColor *string `json:"defaultStoryColor"`
 }
 
 // handleStoryboardColumnUpdate handles updating a column in a storyboard
@@ -134,12 +137,14 @@ func (s *Service) handleStoryboardColumnUpdate(sb *storyboard.Service) http.Hand
 		}
 
 		type updateEvent struct {
-			ColumnID string `json:"id"`
-			Name     string `json:"name"`
+			ColumnID          string  `json:"id"`
+			Name              string  `json:"name"`
+			DefaultStoryColor *string `json:"defaultStoryColor,omitempty"`
 		}
 		sbue := updateEvent{
-			ColumnID: columnID,
-			Name:     sbm.Name,
+			ColumnID:          columnID,
+			Name:              sbm.Name,
+			DefaultStoryColor: sbm.DefaultStoryColor,
 		}
 		updateEventJSON, updateEventErr := json.Marshal(sbue)
 		if updateEventErr != nil {

--- a/internal/http/storyboard_goal.go
+++ b/internal/http/storyboard_goal.go
@@ -11,7 +11,8 @@ import (
 )
 
 type storyboardGoalAddRequestBody struct {
-	Name string `json:"name" validate:"required,min=1"`
+	Name              string  `json:"name" validate:"required,min=1"`
+	DefaultStoryColor *string `json:"defaultStoryColor"`
 }
 
 // handleStoryboardGoalAdd handles adding a goal to a storyboard
@@ -58,7 +59,13 @@ func (s *Service) handleStoryboardGoalAdd(sb *storyboard.Service) http.HandlerFu
 			return
 		}
 
-		newGoal, err := sb.APIEvent(ctx, storyboardID, sessionUserID, "add_goal", sbm.Name)
+		eventValue, err := json.Marshal(sbm)
+		if err != nil {
+			s.Failure(w, r, http.StatusInternalServerError, Errorf(EINVALID, err.Error()))
+			return
+		}
+
+		newGoal, err := sb.APIEvent(ctx, storyboardID, sessionUserID, "add_goal", string(eventValue))
 		if err != nil {
 			s.Logger.Ctx(ctx).Error("handle storyboard goal add error",
 				zap.Error(err),
@@ -73,7 +80,8 @@ func (s *Service) handleStoryboardGoalAdd(sb *storyboard.Service) http.HandlerFu
 }
 
 type storyboardGoalUpdateRequestBody struct {
-	Name string `json:"name" validate:"required,min=1"`
+	Name              string  `json:"name" validate:"required,min=1"`
+	DefaultStoryColor *string `json:"defaultStoryColor"`
 }
 
 // handleStoryboardGoalUpdate handles updating a goal in a storyboard
@@ -128,12 +136,14 @@ func (s *Service) handleStoryboardGoalUpdate(sb *storyboard.Service) http.Handle
 		}
 
 		type updateEvent struct {
-			GoalID string `json:"goalId"`
-			Name   string `json:"name"`
+			GoalID            string  `json:"goalId"`
+			Name              string  `json:"name"`
+			DefaultStoryColor *string `json:"defaultStoryColor,omitempty"`
 		}
 		sbue := updateEvent{
-			GoalID: goalID,
-			Name:   sbm.Name,
+			GoalID:            goalID,
+			Name:              sbm.Name,
+			DefaultStoryColor: sbm.DefaultStoryColor,
 		}
 		updateEventJSON, updateEventErr := json.Marshal(sbue)
 		if updateEventErr != nil {

--- a/internal/http/storyboard_story.go
+++ b/internal/http/storyboard_story.go
@@ -11,8 +11,9 @@ import (
 )
 
 type storyboardStoryAddRequestBody struct {
-	GoalID   string `json:"goalId" validate:"required,uuid"`
-	ColumnID string `json:"columnId" validate:"required,uuid"`
+	GoalID   string  `json:"goalId" validate:"required,uuid"`
+	ColumnID string  `json:"columnId" validate:"required,uuid"`
+	Color    *string `json:"color"`
 }
 
 // handleStoryboardStoryAdd handles adding a story to a storyboard goal column

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -587,20 +587,20 @@ type StoryboardDataSvc interface {
 	UpdateStoryboardPersona(storyboardID string, userID string, personaID string, name string, role string, description string) ([]*thunderdome.StoryboardPersona, error)
 	DeleteStoryboardPersona(storyboardID string, userID string, personaID string) ([]*thunderdome.StoryboardPersona, error)
 
-	CreateStoryboardGoal(storyboardID string, userID string, goalName string) (*thunderdome.StoryboardGoal, error)
-	ReviseGoalName(storyboardID string, userID string, goalID string, goalName string) ([]*thunderdome.StoryboardGoal, error)
+	CreateStoryboardGoal(storyboardID string, userID string, goalName string, defaultStoryColor *string) (*thunderdome.StoryboardGoal, error)
+	ReviseGoalName(storyboardID string, userID string, goalID string, goalName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error)
 	DeleteStoryboardGoal(storyboardID string, userID string, goalID string) ([]*thunderdome.StoryboardGoal, error)
 	GetStoryboardGoals(storyboardID string) []*thunderdome.StoryboardGoal
 	GetStoryboardGoal(storyboardID string, goalID string) (*thunderdome.StoryboardGoal, error)
 
-	CreateStoryboardColumn(storyboardID string, goalID string, userID string) (*thunderdome.StoryboardColumn, error)
-	ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string) ([]*thunderdome.StoryboardGoal, error)
+	CreateStoryboardColumn(storyboardID string, goalID string, userID string, columnName string, defaultStoryColor *string) (*thunderdome.StoryboardColumn, error)
+	ReviseStoryboardColumn(storyboardID string, userID string, columnID string, columnName string, defaultStoryColor *string) ([]*thunderdome.StoryboardGoal, error)
 	DeleteStoryboardColumn(storyboardID string, userID string, columnID string) ([]*thunderdome.StoryboardGoal, error)
 	ColumnPersonaAdd(storyboardID string, columnID string, personaID string) ([]*thunderdome.StoryboardGoal, error)
 	ColumnPersonaRemove(storyboardID string, columnID string, personaID string) ([]*thunderdome.StoryboardGoal, error)
 	MoveStoryboardColumn(storyboardID string, userID string, columnID string, goalID string, placeBeforeID string) error
 
-	CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string) (*thunderdome.StoryboardStory, error)
+	CreateStoryboardStory(storyboardID string, goalID string, columnID string, userID string, storyColor *string) (*thunderdome.StoryboardStory, error)
 	ReviseStoryName(storyboardID string, userID string, storyID string, storyName string) ([]*thunderdome.StoryboardGoal, error)
 	ReviseStoryContent(storyboardID string, userID string, storyID string, storyContent string) ([]*thunderdome.StoryboardGoal, error)
 	ReviseStoryColor(storyboardID string, userID string, storyID string, storyColor string) ([]*thunderdome.StoryboardGoal, error)

--- a/thunderdome/storyboard.go
+++ b/thunderdome/storyboard.go
@@ -31,20 +31,22 @@ type Storyboard struct {
 
 // StoryboardGoal A row in a story mapping board
 type StoryboardGoal struct {
-	ID        string               `json:"id"`
-	Name      string               `json:"name"`
-	Personas  []*StoryboardPersona `json:"personas"`
-	Columns   []*StoryboardColumn  `json:"columns"`
-	SortOrder string               `json:"sort_order"`
+	ID                string               `json:"id"`
+	Name              string               `json:"name"`
+	DefaultStoryColor *string              `json:"default_story_color"`
+	Personas          []*StoryboardPersona `json:"personas"`
+	Columns           []*StoryboardColumn  `json:"columns"`
+	SortOrder         string               `json:"sort_order"`
 }
 
 // StoryboardColumn A column in a storyboard goal
 type StoryboardColumn struct {
-	ID        string               `json:"id"`
-	Name      string               `json:"name"`
-	Personas  []*StoryboardPersona `json:"personas"`
-	Stories   []*StoryboardStory   `json:"stories"`
-	SortOrder string               `json:"sort_order"`
+	ID                string               `json:"id"`
+	Name              string               `json:"name"`
+	DefaultStoryColor *string              `json:"default_story_color"`
+	Personas          []*StoryboardPersona `json:"personas"`
+	Stories           []*StoryboardStory   `json:"stories"`
+	SortOrder         string               `json:"sort_order"`
 }
 
 // StoryboardStory A story in a storyboard goal column

--- a/ui/src/components/storyboard/AddGoal.svelte
+++ b/ui/src/components/storyboard/AddGoal.svelte
@@ -3,6 +3,8 @@
   import Modal from '../global/Modal.svelte';
   import LL from '../../i18n/i18n-svelte';
   import TextInput from '../forms/TextInput.svelte';
+  import StoryColorSelector from './StoryColorSelector.svelte';
+  import type { ColorLegend } from '../../types/storyboard';
   import { onMount } from 'svelte';
 
   interface Props {
@@ -11,6 +13,8 @@
     handleGoalRevision?: any;
     goalId?: string;
     goalName?: string;
+    goalDefaultStoryColor?: string | null;
+    colorLegend?: ColorLegend[];
   }
 
   let {
@@ -19,19 +23,32 @@
     handleGoalRevision = () => {},
     goalId = '',
     goalName = $bindable(''),
+    goalDefaultStoryColor = null,
+    colorLegend = [],
   }: Props = $props();
 
   let focusInput: any = $state();
+  let selectedDefaultStoryColor = $state('');
+
+  $effect(() => {
+    selectedDefaultStoryColor = goalDefaultStoryColor ?? '';
+  });
 
   function handleSubmit(event: Event) {
     event.preventDefault();
 
+    const defaultStoryColor = selectedDefaultStoryColor === '' ? null : selectedDefaultStoryColor;
+
     if (goalId === '') {
-      handleGoalAdd(goalName);
+      handleGoalAdd({
+        name: goalName,
+        defaultStoryColor,
+      });
     } else {
       handleGoalRevision({
         goalId,
         name: goalName,
+        defaultStoryColor,
       });
     }
     toggleAddGoal();
@@ -55,6 +72,19 @@
         name="goalName"
         bind:this={focusInput}
       />
+    </div>
+    <div class="mb-4">
+      <label class="block text-lg text-gray-700 dark:text-gray-300 font-bold mb-2" for="goalDefaultStoryColor">
+        Default Story Color
+      </label>
+      <div id="goalDefaultStoryColor">
+        <StoryColorSelector
+          bind:value={selectedDefaultStoryColor}
+          {colorLegend}
+          allowNone={true}
+          noneLabel="No default"
+        />
+      </div>
     </div>
     <div class="text-right">
       <div>

--- a/ui/src/components/storyboard/AddGoal.test.ts
+++ b/ui/src/components/storyboard/AddGoal.test.ts
@@ -46,7 +46,10 @@ describe('AddGoal component', () => {
     await userEvent.fill(input, 'New Goal');
     await button.click();
 
-    expect(handleGoalAdd).toHaveBeenCalledWith('New Goal');
+    expect(handleGoalAdd).toHaveBeenCalledWith({
+      name: 'New Goal',
+      defaultStoryColor: null,
+    });
     expect(handleGoalAdd).toHaveBeenCalledTimes(1);
     expect(handleGoalRevision).not.toHaveBeenCalled();
     expect(toggleAddGoal).toHaveBeenCalledTimes(1);
@@ -74,6 +77,7 @@ describe('AddGoal component', () => {
     expect(handleGoalRevision).toHaveBeenCalledWith({
       goalId: 'goal-1',
       name: 'Revised Goal',
+      defaultStoryColor: null,
     });
     expect(handleGoalRevision).toHaveBeenCalledTimes(1);
     expect(handleGoalAdd).not.toHaveBeenCalled();
@@ -106,7 +110,10 @@ describe('AddGoal component', () => {
     const button = page.getByRole('button', { name: /save/i });
     await button.click();
 
-    expect(handleGoalAdd).toHaveBeenCalledWith('');
+    expect(handleGoalAdd).toHaveBeenCalledWith({
+      name: '',
+      defaultStoryColor: null,
+    });
     expect(handleGoalAdd).toHaveBeenCalledTimes(1);
     expect(toggleAddGoal).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/components/storyboard/ColumnForm.svelte
+++ b/ui/src/components/storyboard/ColumnForm.svelte
@@ -2,38 +2,52 @@
   import SolidButton from '../global/SolidButton.svelte';
   import Modal from '../global/Modal.svelte';
   import TextInput from '../forms/TextInput.svelte';
+  import StoryColorSelector from './StoryColorSelector.svelte';
   import LL from '../../i18n/i18n-svelte';
+  import type { ColorLegend, StoryboardColumn } from '../../types/storyboard';
   import { onMount } from 'svelte';
 
   interface Props {
     toggleColumnEdit?: any;
     handleColumnRevision?: any;
-    column?: any;
+    column?: StoryboardColumn | any;
+    goalId?: string;
+    colorLegend?: ColorLegend[];
   }
 
   let {
     toggleColumnEdit = () => {},
     handleColumnRevision = () => {},
+    goalId = '',
+    colorLegend = [],
     column = $bindable({
       id: '',
       name: '',
+      default_story_color: null,
       personas: [],
+      stories: [],
+      sort_order: '',
     }),
   }: Props = $props();
 
   let focusInput: any = $state();
   let columnName = $state(column.name);
+  let selectedDefaultStoryColor = $state(column.default_story_color ?? '');
 
   $effect(() => {
     columnName = column.name;
+    selectedDefaultStoryColor = column.default_story_color ?? '';
   });
 
   function handleSubmit(event: SubmitEvent) {
     event.preventDefault();
 
+    const defaultStoryColor = selectedDefaultStoryColor === '' ? null : selectedDefaultStoryColor;
+
     const c = {
       id: column.id,
       name: columnName,
+      defaultStoryColor,
     };
 
     handleColumnRevision(c);
@@ -58,6 +72,19 @@
         name="columnName"
         bind:this={focusInput}
       />
+    </div>
+    <div class="mb-4">
+      <label class="block text-sm text-gray-700 dark:text-gray-400 font-bold mb-2" for="columnDefaultStoryColor">
+        Default Story Color
+      </label>
+      <div id="columnDefaultStoryColor">
+        <StoryColorSelector
+          bind:value={selectedDefaultStoryColor}
+          {colorLegend}
+          allowNone={true}
+          noneLabel="No default"
+        />
+      </div>
     </div>
     <div class="flex justify-end gap-2">
       <SolidButton type="submit">Save</SolidButton>

--- a/ui/src/components/storyboard/ColumnForm.test.ts
+++ b/ui/src/components/storyboard/ColumnForm.test.ts
@@ -58,6 +58,7 @@ describe('ColumnForm component', () => {
     expect(handleColumnRevision).toHaveBeenCalledWith({
       id: 'column-1',
       name: 'In Progress',
+      defaultStoryColor: null,
     });
     expect(handleColumnRevision).toHaveBeenCalledTimes(1);
     expect(toggleColumnEdit).toHaveBeenCalledTimes(1);

--- a/ui/src/components/storyboard/GoalSection.svelte
+++ b/ui/src/components/storyboard/GoalSection.svelte
@@ -13,7 +13,7 @@
     goalIndex: number;
     isFacilitator: boolean;
     handleDelete: any;
-    handleColumnAdd: any;
+    addColumn: any;
     toggleEdit: any;
     columnOrderEditMode: any;
     toggleColumnOrderEdit: any;
@@ -23,7 +23,7 @@
     children,
     toggleEdit = (goalId: String) => () => {},
     handleDelete = (goalId: String) => {},
-    handleColumnAdd = (goalId: String) => {},
+    addColumn = (goalId: String) => {},
     goal = { id: '', columns: [] },
     goalIndex = 0,
     isFacilitator = false,
@@ -53,7 +53,7 @@
   };
 
   const handleColAdd = () => {
-    handleColumnAdd(goal.id);
+    addColumn(goal.id);
   };
 
   const handleToggleColumnOrderEdit = (toggleSubmenu?: () => void) => () => {

--- a/ui/src/components/storyboard/StoryColorSelector.svelte
+++ b/ui/src/components/storyboard/StoryColorSelector.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import type { ColorLegend } from '../../types/storyboard';
+
+  interface Props {
+    value?: string;
+    colorLegend?: ColorLegend[];
+    allowNone?: boolean;
+    noneLabel?: string;
+    onSelect?: (color: string) => void;
+  }
+
+  let {
+    value = $bindable(''),
+    colorLegend = [],
+    allowNone = false,
+    noneLabel = 'No default',
+    onSelect = () => {},
+  }: Props = $props();
+
+  function selectColor(color: string) {
+    return () => {
+      value = color;
+      onSelect(color);
+    };
+  }
+
+  function colorTitle(color: ColorLegend) {
+    return color.legend ? `${color.color} - ${color.legend}` : color.color;
+  }
+</script>
+
+<div class="flex flex-wrap gap-2 pt-1">
+  {#if allowNone}
+    <button
+      type="button"
+      onclick={selectColor('')}
+      class="flex items-center justify-center w-8 h-8 rounded-full border-2 border-dashed border-gray-400 bg-white hover:scale-110 transition-transform dark:border-gray-500 dark:bg-gray-800 dark:ring-offset-gray-800 {value ===
+      ''
+        ? 'ring-2 ring-offset-2'
+        : ''}"
+      title={noneLabel}
+      aria-pressed={value === ''}
+    >
+      <span class="w-2.5 h-2.5 rounded-full bg-gray-400 dark:bg-gray-500"></span>
+      <span class="hidden">{noneLabel}</span>
+    </button>
+  {/if}
+
+  {#each colorLegend as color}
+    <button
+      type="button"
+      onclick={selectColor(color.color)}
+      class="w-8 h-8 rounded-full colorcard-{color.color} hover:scale-110 transition-transform dark:ring-offset-gray-800 {value ===
+      color.color
+        ? 'ring-2 ring-offset-2'
+        : ''}"
+      title={colorTitle(color)}
+      aria-pressed={value === color.color}
+    >
+      <span class="hidden">{colorTitle(color)}</span>
+    </button>
+  {/each}
+</div>
+
+<style lang="postcss">
+  .colorcard-gray {
+    @apply bg-gray-400;
+    @apply ring-gray-400;
+  }
+
+  .colorcard-gray:hover {
+    @apply bg-gray-600;
+    @apply ring-gray-600;
+  }
+
+  .colorcard-red {
+    @apply bg-red-400;
+    @apply ring-red-400;
+  }
+
+  .colorcard-red:hover {
+    @apply bg-red-600;
+    @apply ring-red-600;
+  }
+
+  .colorcard-orange {
+    @apply bg-orange-400;
+    @apply ring-orange-400;
+  }
+
+  .colorcard-orange:hover {
+    @apply bg-orange-600;
+    @apply ring-orange-600;
+  }
+
+  .colorcard-yellow {
+    @apply bg-yellow-400;
+    @apply ring-yellow-400;
+  }
+
+  .colorcard-yellow:hover {
+    @apply bg-yellow-600;
+    @apply ring-yellow-600;
+  }
+
+  .colorcard-green {
+    @apply bg-green-400;
+    @apply ring-green-400;
+  }
+
+  .colorcard-green:hover {
+    @apply bg-green-600;
+    @apply ring-green-600;
+  }
+
+  .colorcard-teal {
+    @apply bg-teal-400;
+    @apply ring-teal-400;
+  }
+
+  .colorcard-teal:hover {
+    @apply bg-teal-600;
+    @apply ring-teal-600;
+  }
+
+  .colorcard-blue {
+    @apply bg-blue-400;
+    @apply ring-blue-400;
+  }
+
+  .colorcard-blue:hover {
+    @apply bg-blue-600;
+    @apply ring-blue-600;
+  }
+
+  .colorcard-indigo {
+    @apply bg-indigo-400;
+    @apply ring-indigo-400;
+  }
+
+  .colorcard-indigo:hover {
+    @apply bg-indigo-600;
+    @apply ring-indigo-600;
+  }
+
+  .colorcard-purple {
+    @apply bg-purple-400;
+    @apply ring-purple-400;
+  }
+
+  .colorcard-purple:hover {
+    @apply bg-purple-600;
+    @apply ring-purple-600;
+  }
+
+  .colorcard-pink {
+    @apply bg-pink-400;
+    @apply ring-pink-400;
+  }
+
+  .colorcard-pink:hover {
+    @apply bg-pink-600;
+    @apply ring-pink-600;
+  }
+</style>

--- a/ui/src/components/storyboard/StoryForm.svelte
+++ b/ui/src/components/storyboard/StoryForm.svelte
@@ -5,6 +5,7 @@
   import LL from '../../i18n/i18n-svelte';
   import TextInput from '../forms/TextInput.svelte';
   import Editor from '../forms/Editor.svelte';
+  import StoryColorSelector from './StoryColorSelector.svelte';
   import { ChevronRight, ChevronDown } from '@lucide/svelte';
   import { onMount } from 'svelte';
   import Comment from '../comments/Comment.svelte';
@@ -45,10 +46,12 @@
   let discussionHidden = $state(true);
   let focusInput: any = $state();
   let storyPoints = $state('');
+  let selectedStoryColor = $state('');
 
   $effect(() => {
     discussionHidden = !discussionExpanded;
     additionalDetailsHidden = !additionalDetailsExpanded;
+    selectedStoryColor = story.color;
   });
 
   const userMap: Map<string, UserDisplay> = $derived(
@@ -220,19 +223,7 @@
       <!-- Story Points and Color -->
       <div>
         <div class="block text-gray-700 dark:text-gray-300 mb-2 text-lg">Story Color</div>
-        <div class="flex space-x-2 pt-1">
-          {#each colorLegend as color}
-            <button
-              onclick={changeColor(color.color)}
-              class="w-8 h-8 rounded-full colorcard-{color.color}
-                  hover:scale-110 transition-transform dark:ring-offset-gray-800 {story.color === color.color
-                ? `ring-2 ring-offset-2`
-                : ''}"
-              title="{color.color}{color.legend !== '' ? ` - ${color.legend}` : ''}"
-              ><span class="hidden">change color</span></button
-            >
-          {/each}
-        </div>
+        <StoryColorSelector bind:value={selectedStoryColor} {colorLegend} onSelect={color => changeColor(color)()} />
       </div>
 
       <!-- Story Content -->
@@ -409,105 +400,3 @@
     </div>
   </div>
 </Modal>
-
-<style lang="postcss">
-  .colorcard-gray {
-    @apply bg-gray-400;
-    @apply ring-gray-400;
-  }
-
-  .colorcard-gray:hover {
-    @apply bg-gray-600;
-    @apply ring-gray-600;
-  }
-
-  .colorcard-red {
-    @apply bg-red-400;
-    @apply ring-red-400;
-  }
-
-  .colorcard-red:hover {
-    @apply bg-red-600;
-    @apply ring-red-600;
-  }
-
-  .colorcard-orange {
-    @apply bg-orange-400;
-    @apply ring-orange-400;
-  }
-
-  .colorcard-orange:hover {
-    @apply bg-orange-600;
-    @apply ring-orange-600;
-  }
-
-  .colorcard-yellow {
-    @apply bg-yellow-400;
-    @apply ring-yellow-400;
-  }
-
-  .colorcard-yellow:hover {
-    @apply bg-yellow-600;
-    @apply ring-yellow-600;
-  }
-
-  .colorcard-green {
-    @apply bg-green-400;
-    @apply ring-green-400;
-  }
-
-  .colorcard-green:hover {
-    @apply bg-green-600;
-    @apply ring-green-600;
-  }
-
-  .colorcard-teal {
-    @apply bg-teal-400;
-    @apply ring-teal-400;
-  }
-
-  .colorcard-teal:hover {
-    @apply bg-teal-600;
-    @apply ring-teal-600;
-  }
-
-  .colorcard-blue {
-    @apply bg-blue-400;
-    @apply ring-blue-400;
-  }
-
-  .colorcard-blue:hover {
-    @apply bg-blue-600;
-    @apply ring-blue-600;
-  }
-
-  .colorcard-indigo {
-    @apply bg-indigo-400;
-    @apply ring-indigo-400;
-  }
-
-  .colorcard-indigo:hover {
-    @apply bg-indigo-600;
-    @apply ring-indigo-600;
-  }
-
-  .colorcard-purple {
-    @apply bg-purple-400;
-    @apply ring-purple-400;
-  }
-
-  .colorcard-purple:hover {
-    @apply bg-purple-600;
-    @apply ring-purple-600;
-  }
-
-  .colorcard-pink {
-    @apply bg-pink-400;
-    @apply ring-pink-400;
-  }
-
-  .colorcard-pink:hover {
-    @apply bg-pink-600;
-    @apply ring-pink-600;
-  }
-</style>

--- a/ui/src/pages/storyboard/Storyboard.svelte
+++ b/ui/src/pages/storyboard/Storyboard.svelte
@@ -84,6 +84,8 @@
   let showColorLegendForm = $state(false);
   let showPersonas = $state(false);
   let editColumn: StoryboardColumn | null = $state(null);
+  let showColumnForm = $state(false);
+  let columnFormGoalId = $state('');
   let showDeleteStoryboard = $state(false);
   let showEditStoryboard = $state(false);
   let showExportStoryboard = $state(false);
@@ -212,15 +214,6 @@
     );
   };
 
-  const addStoryColumn = (goalId: String) => {
-    sendSocketEvent(
-      'add_column',
-      JSON.stringify({
-        goalId,
-      }),
-    );
-  };
-
   const handleAddFacilitator = (userId: string) => {
     sendSocketEvent(
       'facilitator_add',
@@ -270,9 +263,22 @@
     };
   }
 
+  function closeColumnForm() {
+    showColumnForm = false;
+    columnFormGoalId = '';
+    editColumn = null;
+  }
+
   function toggleColumnEdit(column: StoryboardColumn | null = null) {
     return () => {
-      editColumn = editColumn != null ? null : column;
+      if (column) {
+        editColumn = column;
+        columnFormGoalId = '';
+        showColumnForm = true;
+        return;
+      }
+
+      closeColumnForm();
     };
   }
 
@@ -301,6 +307,7 @@
   let showAddGoal = $state(false);
   let reviseGoalId = $state('');
   let reviseGoalName = $state('');
+  let reviseGoalDefaultStoryColor = $state<string | null>(null);
 
   const toggleAddGoal = (goalId?: string) => () => {
     if (goalId) {
@@ -308,16 +315,18 @@
       if (goal) {
         reviseGoalId = goalId;
         reviseGoalName = goal.name;
+        reviseGoalDefaultStoryColor = goal.default_story_color;
       }
     } else {
       reviseGoalId = '';
       reviseGoalName = '';
+      reviseGoalDefaultStoryColor = null;
     }
     showAddGoal = !showAddGoal;
   };
 
-  const handleGoalAdd = (goalName: string) => {
-    sendSocketEvent('add_goal', goalName);
+  const handleGoalAdd = (goal: { name: string; defaultStoryColor: string | null }) => {
+    sendSocketEvent('add_goal', JSON.stringify(goal));
   };
 
   const handleGoalRevision = (updatedGoal: any) => {
@@ -330,6 +339,17 @@
 
   const handleColumnRevision = (column: StoryboardColumn) => {
     sendSocketEvent('revise_column', JSON.stringify(column));
+  };
+
+  const addColumn = (goalId: string) => {
+    sendSocketEvent(
+      'add_column',
+      JSON.stringify({
+        goalId,
+        name: '',
+        defaultStoryColor: null,
+      }),
+    );
   };
 
   const handleLegendRevision = (legend: ColorLegend[]) => {
@@ -582,7 +602,7 @@
     <GoalSection
       {goal}
       handleDelete={handleGoalDeletion}
-      handleColumnAdd={addStoryColumn}
+      {addColumn}
       toggleEdit={toggleAddGoal}
       {goalIndex}
       {isFacilitator}
@@ -604,7 +624,7 @@
             different types of work, or however else you'd like to group your stories.
           </p>
           <div class="mt-6 flex justify-center">
-            <SolidButton color="green" onClick={() => addStoryColumn(goal.id)} testid="goal-col-add-empty">
+            <SolidButton color="green" onClick={() => addColumn(goal.id)} testid="goal-col-add-empty">
               <Plus class="inline-block w-4 h-4" />&nbsp;{$LL.storyboardAddColumn()}
             </SolidButton>
           </div>
@@ -636,11 +656,19 @@
     {handleGoalRevision}
     goalId={reviseGoalId}
     goalName={reviseGoalName}
+    goalDefaultStoryColor={reviseGoalDefaultStoryColor}
+    colorLegend={storyboard.color_legend}
   />
 {/if}
 
-{#if editColumn}
-  <ColumnForm {handleColumnRevision} toggleColumnEdit={toggleColumnEdit(null)} column={editColumn} />
+{#if showColumnForm && editColumn}
+  <ColumnForm
+    {handleColumnRevision}
+    toggleColumnEdit={closeColumnForm}
+    column={editColumn}
+    goalId={columnFormGoalId}
+    colorLegend={storyboard.color_legend}
+  />
 {/if}
 
 {#if showColorLegendForm}

--- a/ui/src/types/storyboard.ts
+++ b/ui/src/types/storyboard.ts
@@ -20,6 +20,7 @@ export type Storyboard = {
 };
 
 export type StoryboardColumn = {
+  default_story_color: string | null;
   id: string;
   name: string;
   personas: Array<StoryboardPersona>;
@@ -29,6 +30,7 @@ export type StoryboardColumn = {
 
 export type StoryboardGoal = {
   columns: Array<StoryboardColumn>;
+  default_story_color: string | null;
   id: string;
   name: string;
   personas: Array<StoryboardPersona>;


### PR DESCRIPTION
## Description

Add storyboard goal and column default story color settings.

Hierarchy is 'gray' -> Goal -> Column with gray being the default when goal or column do not have defaults set and the story isn't passing a defined color (e.g. during creation).

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Dependency updates
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Related Tickets & Documents

This resolves #855

## Screenshots/Recordings

<img width="817" height="412" alt="image" src="https://github.com/user-attachments/assets/827bf0bb-25d4-4c80-a431-57ef20d059e5" />

<img width="768" height="367" alt="image" src="https://github.com/user-attachments/assets/d57d9ea2-bc8b-4bde-80c7-d266a50ebf90" />

## Steps to QA

<!-- 
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- note: PRs with deleted sections will be marked invalid -->